### PR TITLE
Create CSV. Read Governors as well as Representatives. Recognise Utah.

### DIFF
--- a/candidate.py
+++ b/candidate.py
@@ -193,6 +193,12 @@ def normalize_location(state, district):
   full = us.states.lookup(unicode(unverified_state))
   if full:
     normalized_state = full.name
+  # https://github.com/unitedstates/python-us/issues/13. We can't guarantee that
+  # everyone will have jellyfish 0.5.3 or greater, so... hackorama.
+  elif unverified_state == "Utah":
+    normalized_state = "Utah"
+  else:
+    print "couldn't look up %s " % unicode(unverified_state)
 
   return (normalized_state, normalized_district)
 

--- a/candidatebot.py
+++ b/candidatebot.py
@@ -3,6 +3,7 @@
 """This script reads a list of candidates from various data sources and makes
 sure that they each have a wikipedia page, creating it if necessary"""
 
+import csv
 import getpass
 import sys
 
@@ -18,11 +19,15 @@ DRAFT_PREFIX = "User:Candidatebot/sandbox/"
 YAML_FILE = "candidates.yaml"
 XML_FILE = "CandidateSummaryAction.xml"
 HOUSE_FILE = "house.html"
+GOVERNOR_FILE = "governor.html"
 # Limit what this does during testing.
-MAX_PAGES_TO_CREATE = 2
+MAX_PAGES_TO_CREATE = 0
+
+
 
 def main():
   """Gets a bunch of candidate information and tries to create pages for it."""
+
   if not credentials.USERNAME:
     print ("Please specify a user name in the variable USERNAME in a "
            "credentials.py file in the root directory")
@@ -42,30 +47,41 @@ def main():
 
   created = 0
 
-  #for person in candidate.new_from_fec_xml(XML_FILE):
-  #for person in candidate.new_from_yaml(YAML_FILE):
-  for person in candidate.new_from_wikipedia_page(HOUSE_FILE):
-    print "Person: %s, %s" % (person.name(), person.office_and_district())
-    if created >= MAX_PAGES_TO_CREATE:
-      print "Already created %s pages. Stopping." % MAX_PAGES_TO_CREATE
-      break
-    # Check if a live page exists.
-    existing_page = wiki.does_page_exist(person.name())
-    if existing_page:
-      print "Page already exists at %s" % existing_page
+
+  csvfile = open('candidates.csv', 'wb')
+  writer = csv.writer(csvfile, quoting=csv.QUOTE_ALL)
+  writer.writerow(candidate.Candidate.ordered_fields())
+
+  files = [ # (HOUSE_FILE, "house"),
+            (GOVERNOR_FILE, "governor")]
+
+  print "Creating no more than %s wiki pages." % MAX_PAGES_TO_CREATE
+  for filename, office in files:
+    print "### %s" % filename
+    #for person in candidate.new_from_fec_xml(XML_FILE):
+    #for person in candidate.new_from_yaml(YAML_FILE):
+    for person in candidate.new_from_wikipedia_page(filename, office):
+      writer.writerow(person.as_list())
+      if created == MAX_PAGES_TO_CREATE:
+        continue
+      # Check if a live page exists.
+      existing_page = wiki.does_page_exist(person.name())
+      if existing_page:
+        print "Page already exists at %s" % existing_page
+        continue
+      # Check for an existing draft page.
+      existing_draft = wiki.does_draft_exist(person.name())
+      if existing_draft:
+        print "Draft already exists at %s" % existing_draft
+        continue
+      print "Creating wikipedia page for %s (for %s)" % (
+        person.name(), person.office_and_district())
+      new_page = wiki.create_page(person, create_draft=True)
+      if new_page:
+        print "Created %s" % new_page
+        created += 1
+      else:
+        print "Failed to create a page for %s" % person.name()
       continue
-    # Check for an existing draft page.
-    existing_draft = wiki.does_draft_exist(person.name())
-    if existing_draft:
-      print "Draft already exists at %s" % existing_draft
-      continue
-    print "Creating wikipedia page for %s (for %s)" % (
-      person.name(), person.office_and_district())
-    new_page = wiki.create_page(person, create_draft=True)
-    if new_page:
-      print "Created %s" % new_page
-      created += 1
-    else:
-      print "Failed to create a page for %s" % person.name()
 
 main()

--- a/governor.html
+++ b/governor.html
@@ -1,0 +1,1543 @@
+<!DOCTYPE html>
+<html class="client-nojs" lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8"/>
+<title>United States gubernatorial elections, 2016 - Wikipedia, the free encyclopedia</title>
+<script>document.documentElement.className = document.documentElement.className.replace( /(^|\s)client-nojs(\s|$)/, "$1client-js$2" );</script>
+<script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"United_States_gubernatorial_elections,_2016","wgTitle":"United States gubernatorial elections, 2016","wgCurRevisionId":742759949,"wgRevisionId":742759949,"wgArticleId":38702920,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":["Use mdy dates from January 2016","United States gubernatorial elections, 2016"],"wgBreakFrames":false,"wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgMonthNamesShort":["","Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"wgRelevantPageName":"United_States_gubernatorial_elections,_2016","wgRelevantArticleId":38702920,"wgRequestId":"V-UtWApAIDAAAEmrWV4AAAAF","wgIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgWikiEditorEnabledModules":{"toolbar":true,"dialogs":true,"preview":false,"publish":false},"wgBetaFeaturesFeatures":[],"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true,"wgVisualEditor":{"pageLanguageCode":"en","pageLanguageDir":"ltr","usePageImages":true,"usePageDescriptions":true},"wgPreferredVariant":"en","wgMFDisplayWikibaseDescriptions":{"search":true,"nearby":true,"watchlist":true,"tagline":false},"wgRelatedArticles":null,"wgRelatedArticlesUseCirrusSearch":true,"wgRelatedArticlesOnlyUseCirrusSearch":false,"wgULSCurrentAutonym":"English","wgNoticeProject":"wikipedia","wgCentralNoticeCookiesToDelete":[],"wgCentralNoticeCategoriesUsingLegacy":["Fundraising","fundraising"],"wgCategoryTreePageCategoryOptions":"{\"mode\":0,\"hideprefix\":20,\"showcount\":true,\"namespaces\":false}","wgFlaggedRevsParams":{"tags":{"status":{"levels":1,"quality":2,"pristine":3}}},"wgStableRevisionId":null,"wgWikibaseItemId":"Q6496595","wgCentralAuthMobileDomain":false,"wgVisualEditorToolbarScrollOffset":0,"wgEditSubmitButtonLabelPublish":false});mw.loader.state({"ext.globalCssJs.user.styles":"ready","ext.globalCssJs.site.styles":"ready","site.styles":"ready","noscript":"ready","user.styles":"ready","user.cssprefs":"ready","user":"ready","user.options":"loading","user.tokens":"loading","ext.cite.styles":"ready","wikibase.client.init":"ready","ext.visualEditor.desktopArticleTarget.noscript":"ready","ext.uls.interlanguage":"ready","ext.tmh.thumbnail.styles":"ready","ext.wikimediaBadges":"ready","mediawiki.legacy.shared":"ready","mediawiki.legacy.commonPrint":"ready","mediawiki.sectionAnchor":"ready","mediawiki.skinning.interface":"ready","skins.vector.styles":"ready","ext.globalCssJs.user":"ready","ext.globalCssJs.site":"ready"});mw.loader.implement("user.options",function($,jQuery,require,module){mw.user.options.set({"variant":"en"});});mw.loader.implement("user.tokens",function ( $, jQuery, require, module ) {
+mw.user.tokens.set({"editToken":"+\\","patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});/*@nomin*/;
+
+});mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","ext.centralauth.centralautologin","mmv.head","ext.visualEditor.desktopArticleTarget.init","ext.uls.interface","ext.quicksurveys.init","mw.MediaWikiPlayer.loader","mw.PopUpMediaTransform","skins.vector.js"]);});</script>
+<link rel="stylesheet" href="/w/load.php?debug=false&amp;lang=en&amp;modules=ext.cite.styles%7Cext.gadget.DRN-wizard%2CReferenceTooltips%2Ccharinsert%2Cextra-toolbar-buttons%2Cfeatured-articles-links%2CrefToolbar%2Cswitcher%2Cteahouse%2Cwatchlist-notice%7Cext.tmh.thumbnail.styles%7Cext.uls.interlanguage%7Cext.visualEditor.desktopArticleTarget.noscript%7Cext.wikimediaBadges%7Cmediawiki.legacy.commonPrint%2Cshared%7Cmediawiki.sectionAnchor%7Cmediawiki.skinning.interface%7Cskins.vector.styles%7Cwikibase.client.init&amp;only=styles&amp;skin=vector"/>
+<script async="" src="/w/load.php?debug=false&amp;lang=en&amp;modules=startup&amp;only=scripts&amp;skin=vector"></script>
+<meta name="ResourceLoaderDynamicStyles" content=""/>
+<link rel="stylesheet" href="/w/load.php?debug=false&amp;lang=en&amp;modules=site.styles&amp;only=styles&amp;skin=vector"/>
+<meta name="generator" content="MediaWiki 1.28.0-wmf.20"/>
+<meta name="referrer" content="origin-when-cross-origin"/>
+<link rel="alternate" href="android-app://org.wikipedia/http/en.m.wikipedia.org/wiki/United_States_gubernatorial_elections,_2016"/>
+<link rel="alternate" type="application/x-wiki" title="Edit this page" href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit"/>
+<link rel="edit" title="Edit this page" href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit"/>
+<link rel="apple-touch-icon" href="/static/apple-touch/wikipedia.png"/>
+<link rel="shortcut icon" href="/static/favicon/wikipedia.ico"/>
+<link rel="search" type="application/opensearchdescription+xml" href="/w/opensearch_desc.php" title="Wikipedia (en)"/>
+<link rel="EditURI" type="application/rsd+xml" href="//en.wikipedia.org/w/api.php?action=rsd"/>
+<link rel="copyright" href="//creativecommons.org/licenses/by-sa/3.0/"/>
+<link rel="canonical" href="https://en.wikipedia.org/wiki/United_States_gubernatorial_elections,_2016"/>
+<link rel="dns-prefetch" href="//login.wikimedia.org"/>
+<link rel="dns-prefetch" href="//meta.wikimedia.org" />
+</head>
+<body class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject page-United_States_gubernatorial_elections_2016 rootpage-United_States_gubernatorial_elections_2016 skin-vector action-view feature-page-action-bar-v2">		<div id="mw-page-base" class="noprint"></div>
+		<div id="mw-head-base" class="noprint"></div>
+		<div id="content" class="mw-body" role="main">
+			<a id="top"></a>
+
+							<div id="siteNotice"><!-- CentralNotice --></div>
+						<div class="mw-indicators">
+</div>
+			<h1 id="firstHeading" class="firstHeading" lang="en">United States gubernatorial elections, 2016</h1>
+									<div id="bodyContent" class="mw-body-content">
+									<div id="siteSub">From Wikipedia, the free encyclopedia</div>
+								<div id="contentSub"></div>
+												<div id="jump-to-nav" class="mw-jump">
+					Jump to:					<a href="#mw-head">navigation</a>, 					<a href="#p-search">search</a>
+				</div>
+				<div id="mw-content-text" lang="en" dir="ltr" class="mw-content-ltr"><table class="infobox vevent" style="font-size: 88%; line-height: 1.5em; width:320px">
+<caption class="summary" style="font-size: 125%; font-weight: bold">United States gubernatorial elections, 2016</caption>
+<tr>
+<td colspan="4" style="text-align:center;"><span class="flagicon"><a href="/wiki/United_States" title="United States"><img alt="United States" src="//upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/50px-Flag_of_the_United_States.svg.png" width="50" height="26" class="thumbborder" srcset="//upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/75px-Flag_of_the_United_States.svg.png 1.5x, //upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/100px-Flag_of_the_United_States.svg.png 2x" data-file-width="1235" data-file-height="650" /></a></span>
+<hr /></td>
+</tr>
+<tr>
+<td colspan="4">
+<table cellspacing="0" cellpadding="0" style="background:transparent; width:100%;">
+<tr>
+<td style="width:25%;text-align:left;" class="noprint"><a href="/wiki/United_States_gubernatorial_elections,_2015" title="United States gubernatorial elections, 2015">2015</a>&#160;←<br /></td>
+<td style="width:50%;text-align:center;"><b>November 8, 2016</b></td>
+<td style="width:25%;text-align:right;" class="noprint">→&#160;<a href="/wiki/United_States_gubernatorial_elections,_2017" title="United States gubernatorial elections, 2017">2017</a><br /></td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td colspan="4">
+<table style="background:transparent; width:100%;">
+<tr>
+<th colspan="4" style="text-align:center"><small>12 <a href="/wiki/Governor_(United_States)" title="Governor (United States)">state governorships</a>; 2 territorial governorships</small></th>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td colspan="4" style="text-align:center">
+<hr />
+<p><a href="/wiki/File:United_States_gubernatorial_elections,_2016.svg" class="image"><img alt="United States gubernatorial elections, 2016.svg" src="//upload.wikimedia.org/wikipedia/commons/thumb/0/02/United_States_gubernatorial_elections%2C_2016.svg/320px-United_States_gubernatorial_elections%2C_2016.svg.png" width="320" height="198" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/0/02/United_States_gubernatorial_elections%2C_2016.svg/480px-United_States_gubernatorial_elections%2C_2016.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/0/02/United_States_gubernatorial_elections%2C_2016.svg/640px-United_States_gubernatorial_elections%2C_2016.svg.png 2x" data-file-width="959" data-file-height="593" /></a></p>
+</td>
+</tr>
+<tr>
+<td colspan="4" style="text-align:center">
+<div class="legend"><span class="legend-color" style="display:inline-block; width:1.5em; height:1.5em; margin:1px 0; border:1px solid black; background-color: #3072af; color:black; font-size:100%; text-align:center;">&#160;</span>&#160;Democratic incumbent eligible for re-election</div>
+<div class="legend"><span class="legend-color" style="display:inline-block; width:1.5em; height:1.5em; margin:1px 0; border:1px solid black; background-color: #3399ff; color:black; font-size:100%; text-align:center;">&#160;</span>&#160;Term-limited or retiring Democrat</div>
+<div class="legend"><span class="legend-color" style="display:inline-block; width:1.5em; height:1.5em; margin:1px 0; border:1px solid black; background-color: #d53034; color:black; font-size:100%; text-align:center;">&#160;</span>&#160;Republican incumbent eligible for re-election</div>
+<div class="legend"><span class="legend-color" style="display:inline-block; width:1.5em; height:1.5em; margin:1px 0; border:1px solid black; background-color: #f25559; color:black; font-size:100%; text-align:center;">&#160;</span>&#160;Term-limited or retiring Republican</div>
+<div class="legend"><span class="legend-color" style="display:inline-block; width:1.5em; height:1.5em; margin:1px 0; border:1px solid black; background-color: #d5d3d5; color:black; font-size:100%; text-align:center;">&#160;</span>&#160;No election</div>
+</td>
+</tr>
+</table>
+<p>The <b>United States gubernatorial elections of 2016</b> will be held on November 8, 2016 in the states of <a href="/wiki/Delaware" title="Delaware">Delaware</a>, <a href="/wiki/Indiana" title="Indiana">Indiana</a>, <a href="/wiki/Missouri" title="Missouri">Missouri</a>, <a href="/wiki/Montana" title="Montana">Montana</a>, <a href="/wiki/New_Hampshire" title="New Hampshire">New Hampshire</a>, <a href="/wiki/North_Carolina" title="North Carolina">North Carolina</a>, <a href="/wiki/North_Dakota" title="North Dakota">North Dakota</a>, <a href="/wiki/Oregon" title="Oregon">Oregon</a>, <a href="/wiki/Utah" title="Utah">Utah</a>, <a href="/wiki/Vermont" title="Vermont">Vermont</a>, <a href="/wiki/Washington_(state)" title="Washington (state)">Washington</a>, and <a href="/wiki/West_Virginia" title="West Virginia">West Virginia</a>. The <a href="/wiki/US_territories" class="mw-redirect" title="US territories">US territories</a> of <a href="/wiki/Puerto_Rico" title="Puerto Rico">Puerto Rico</a> and <a href="/wiki/American_Samoa" title="American Samoa">American Samoa</a> will also hold gubernatorial elections. In addition, special elections may take place (depending on state law) if other gubernatorial seats are vacated. The last regular gubernatorial elections for nine of the twelve states took place in <a href="/wiki/United_States_gubernatorial_elections,_2012" title="United States gubernatorial elections, 2012">2012</a>. The last gubernatorial elections for New Hampshire, Oregon, and Vermont took place in <a href="/wiki/United_States_gubernatorial_elections,_2014" title="United States gubernatorial elections, 2014">2014</a>, as Oregon is holding a special election due to the resignation of governor <a href="/wiki/John_Kitzhaber" title="John Kitzhaber">John Kitzhaber</a>, while the governors of New Hampshire and Vermont both serve two-year terms. The 2016 gubernatorial elections will take place concurrently with several other <a href="/wiki/United_States_elections,_2016" title="United States elections, 2016">federal, state, and local elections</a>, including the <a href="/wiki/United_States_presidential_election,_2016" title="United States presidential election, 2016">2016 presidential election</a>.</p>
+<p></p>
+<div id="toc" class="toc">
+<div id="toctitle">
+<h2>Contents</h2>
+</div>
+<ul>
+<li class="toclevel-1 tocsection-1"><a href="#Election_predictions"><span class="tocnumber">1</span> <span class="toctext">Election predictions</span></a></li>
+<li class="toclevel-1 tocsection-2"><a href="#Primary_dates"><span class="tocnumber">2</span> <span class="toctext">Primary dates</span></a></li>
+<li class="toclevel-1 tocsection-3"><a href="#Race_Summary"><span class="tocnumber">3</span> <span class="toctext">Race Summary</span></a>
+<ul>
+<li class="toclevel-2 tocsection-4"><a href="#States"><span class="tocnumber">3.1</span> <span class="toctext">States</span></a></li>
+<li class="toclevel-2 tocsection-5"><a href="#Territories"><span class="tocnumber">3.2</span> <span class="toctext">Territories</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-6"><a href="#Partisan_control_of_states"><span class="tocnumber">4</span> <span class="toctext">Partisan control of states</span></a></li>
+<li class="toclevel-1 tocsection-7"><a href="#Retiring_and_term-limited_Democratic_incumbents"><span class="tocnumber">5</span> <span class="toctext">Retiring and term-limited Democratic incumbents</span></a>
+<ul>
+<li class="toclevel-2 tocsection-8"><a href="#Jack_Markell_.28Delaware.29"><span class="tocnumber">5.1</span> <span class="toctext">Jack Markell (Delaware)</span></a></li>
+<li class="toclevel-2 tocsection-9"><a href="#Jay_Nixon_.28Missouri.29"><span class="tocnumber">5.2</span> <span class="toctext">Jay Nixon (Missouri)</span></a></li>
+<li class="toclevel-2 tocsection-10"><a href="#Maggie_Hassan_.28New_Hampshire.29"><span class="tocnumber">5.3</span> <span class="toctext">Maggie Hassan (New Hampshire)</span></a></li>
+<li class="toclevel-2 tocsection-11"><a href="#Alejandro_Garc.C3.ADa_Padilla_.28Puerto_Rico.29"><span class="tocnumber">5.4</span> <span class="toctext">Alejandro García Padilla (Puerto Rico)</span></a></li>
+<li class="toclevel-2 tocsection-12"><a href="#Peter_Shumlin_.28Vermont.29"><span class="tocnumber">5.5</span> <span class="toctext">Peter Shumlin (Vermont)</span></a></li>
+<li class="toclevel-2 tocsection-13"><a href="#Earl_Ray_Tomblin_.28West_Virginia.29"><span class="tocnumber">5.6</span> <span class="toctext">Earl Ray Tomblin (West Virginia)</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-14"><a href="#Retiring_Republican_incumbents"><span class="tocnumber">6</span> <span class="toctext">Retiring Republican incumbents</span></a>
+<ul>
+<li class="toclevel-2 tocsection-15"><a href="#Jack_Dalrymple_.28North_Dakota.29"><span class="tocnumber">6.1</span> <span class="toctext">Jack Dalrymple (North Dakota)</span></a></li>
+<li class="toclevel-2 tocsection-16"><a href="#Mike_Pence_.28Indiana.29"><span class="tocnumber">6.2</span> <span class="toctext">Mike Pence (Indiana)</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-17"><a href="#Democratic_incumbents_running_for_re-election"><span class="tocnumber">7</span> <span class="toctext">Democratic incumbents running for re-election</span></a>
+<ul>
+<li class="toclevel-2 tocsection-18"><a href="#Kate_Brown_.28Oregon.29"><span class="tocnumber">7.1</span> <span class="toctext">Kate Brown (Oregon)</span></a></li>
+<li class="toclevel-2 tocsection-19"><a href="#Steve_Bullock_.28Montana.29"><span class="tocnumber">7.2</span> <span class="toctext">Steve Bullock (Montana)</span></a></li>
+<li class="toclevel-2 tocsection-20"><a href="#Jay_Inslee_.28Washington.29"><span class="tocnumber">7.3</span> <span class="toctext">Jay Inslee (Washington)</span></a></li>
+<li class="toclevel-2 tocsection-21"><a href="#Lolo_Letalu_Matalasi_Moliga_.28American_Samoa.29"><span class="tocnumber">7.4</span> <span class="toctext">Lolo Letalu Matalasi Moliga (American Samoa)</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-22"><a href="#Republican_incumbents_running_for_re-election"><span class="tocnumber">8</span> <span class="toctext">Republican incumbents running for re-election</span></a>
+<ul>
+<li class="toclevel-2 tocsection-23"><a href="#Pat_McCrory_.28North_Carolina.29"><span class="tocnumber">8.1</span> <span class="toctext">Pat McCrory (North Carolina)</span></a></li>
+<li class="toclevel-2 tocsection-24"><a href="#Gary_Herbert_.28Utah.29"><span class="tocnumber">8.2</span> <span class="toctext">Gary Herbert (Utah)</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-25"><a href="#References"><span class="tocnumber">9</span> <span class="toctext">References</span></a></li>
+</ul>
+</div>
+<p></p>
+<h2><span class="mw-headline" id="Election_predictions">Election predictions</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=1" title="Edit section: Election predictions">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>Several sites and individuals publish predictions of competitive seats. These predictions look at factors such as the strength of the <a href="/wiki/Incumbent" title="Incumbent">incumbent</a> (if the incumbent is running for re-election), the strength of the candidates, and the partisan leanings of the state (reflected in part by the state's <a href="/wiki/Cook_Partisan_Voting_Index" class="mw-redirect" title="Cook Partisan Voting Index">Cook Partisan Voting Index</a> rating). The predictions assign ratings to each seat, with the rating indicating the predicted advantage that a party has in winning that seat. Most election predictors use "<u>tossup</u>" to indicate that neither party has an advantage, "<u>lean</u>" to indicate that one party has a slight advantage, "<u>likely" or "favored</u>" to indicate that one party has a significant but not insurmountable advantage, and "<u>safe" or "solid</u>" to indicate that one party has a near-certain chance of victory. Some predictions also include a "<u>tilt</u>" rating that indicates that one party has an advantage that is not quite as strong as the "lean" rating would indicate.</p>
+<table class="wikitable sortable" style="text-align:center">
+<tr valign="bottom">
+<th>State</th>
+<th><a href="/wiki/Cook_Partisan_Voting_Index" class="mw-redirect" title="Cook Partisan Voting Index">CPVI</a></th>
+<th>Incumbent<sup id="cite_ref-1" class="reference"><a href="#cite_note-1">[1]</a></sup></th>
+<th>Last<br />
+race</th>
+<th><a href="/wiki/Cook_Political_Report" class="mw-redirect" title="Cook Political Report">Cook</a><br />
+<small>August 12,<br />
+2016</small><sup id="cite_ref-Cook_Predictions_2-0" class="reference"><a href="#cite_note-Cook_Predictions-2">[2]</a></sup></th>
+<th><a href="/wiki/Daily_Kos" title="Daily Kos">DKE</a><br />
+<small>August 19,<br />
+2016</small><sup id="cite_ref-3" class="reference"><a href="#cite_note-3">[3]</a></sup></th>
+<th><a href="/wiki/Stuart_Rothenberg" title="Stuart Rothenberg">Roth.</a><br />
+<small>August 5,<br />
+2016</small><sup id="cite_ref-4" class="reference"><a href="#cite_note-4">[4]</a></sup></th>
+<th><a href="/wiki/Sabato%27s_Crystal_Ball" title="Sabato's Crystal Ball">Sab.</a><br />
+<small>September 7,<br />
+2016</small><sup id="cite_ref-Sabato_Predictons_5-0" class="reference"><a href="#cite_note-Sabato_Predictons-5">[5]</a></sup></th>
+<th><a href="/wiki/RealClearPolitics" title="RealClearPolitics">RCP</a></th>
+<th>Median</th>
+<th>Winner</th>
+</tr>
+<tr>
+<th style="background:#B0CEFF"><a href="#Delaware">Delaware</a></th>
+<td style="background:#99f"><span style="display:none;" class="sortkey">092 !</span><span class="sorttext">D+8</span></td>
+<td style="background:#B0CEFF"><span style="display:none;" class="sortkey">098 !</span><span class="sorttext">(<a href="/wiki/Jack_Markell" title="Jack Markell">Jack Markell</a>)</span> (D)</td>
+<td style="background:#B0CEFF">69.3% D</td>
+<td style="background:#66f"><span style="display:none;" class="sortkey">096 !</span><span class="sorttext">Safe D</span></td>
+<td style="background:#99f"><span style="display:none;" class="sortkey">097 !</span><span class="sorttext">Likely D</span></td>
+<td style="background:#66f"><span style="display:none;" class="sortkey">096 !</span><span class="sorttext">Safe D</span></td>
+<td style="background:#66f"><span style="display:none;" class="sortkey">096 !</span><span class="sorttext">Safe D</span></td>
+<td style="background:#fff"></td>
+<td style="background:#66f"><span style="display:none;" class="sortkey">096 !</span><span class="sorttext">Safe D</span></td>
+<td style="background:#fff">TBD</td>
+</tr>
+<tr>
+<th style="background:#FFB6B6"><a href="#Indiana">Indiana</a></th>
+<td style="background:#f99"><span style="display:none;" class="sortkey">105 !</span><span class="sorttext">R+5</span></td>
+<td style="background:#FFB6B6"><span style="display:none;" class="sortkey">101 !</span><span class="sorttext">(<a href="/wiki/Mike_Pence" title="Mike Pence">Mike Pence</a>)</span> (R)</td>
+<td style="background:#FFB6B6">49.4% R</td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fcc"><span style="display:none;" class="sortkey">102 !</span><span class="sorttext">Lean R</span></td>
+<td style="background:#fcc"><span style="display:none;" class="sortkey">102 !</span><span class="sorttext">Lean R</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"></td>
+<td style="background:#fdd"><span style="display:none;" class="sortkey">101 !</span><span class="sorttext">Tilt R</span></td>
+<td style="background:#fff">TBD</td>
+</tr>
+<tr>
+<th style="background:#FFB6B6"><a href="#Missouri">Missouri</a></th>
+<td style="background:#f99"><span style="display:none;" class="sortkey">105 !</span><span class="sorttext">R+5</span></td>
+<td style="background:#B0CEFF"><span style="display:none;" class="sortkey">098 !</span><span class="sorttext">(<a href="/wiki/Jay_Nixon" title="Jay Nixon">Jay Nixon</a>)</span> (D)</td>
+<td style="background:#B0CEFF">54.6% D</td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff">TBD</td>
+</tr>
+<tr>
+<th style="background:#FFB6B6"><a href="#Montana">Montana</a></th>
+<td style="background:#f99"><span style="display:none;" class="sortkey">107 !</span><span class="sorttext">R+7</span></td>
+<td style="background:#B0CEFF"><span style="display:none;" class="sortkey">099 !</span><span class="sorttext"><a href="/wiki/Steve_Bullock_(Montana_politician)" title="Steve Bullock (Montana politician)">Steve Bullock</a></span> (D)</td>
+<td style="background:#B0CEFF">48.9% D</td>
+<td style="background:#ccf"><span style="display:none;" class="sortkey">098 !</span><span class="sorttext">Lean D</span></td>
+<td style="background:#ccf"><span style="display:none;" class="sortkey">098 !</span><span class="sorttext">Lean D</span></td>
+<td style="background:#ccf"><span style="display:none;" class="sortkey">098 !</span><span class="sorttext">Lean D</span></td>
+<td style="background:#ccf"><span style="display:none;" class="sortkey">098 !</span><span class="sorttext">Lean D</span></td>
+<td style="background:#fff"></td>
+<td style="background:#ccf"><span style="display:none;" class="sortkey">098 !</span><span class="sorttext">Lean D</span></td>
+<td style="background:#fff">TBD</td>
+</tr>
+<tr>
+<th style="background:#B0CEFF"><a href="#New_Hampshire">New Hampshire</a></th>
+<td style="background:#ccf"><span style="display:none;" class="sortkey">099 !</span><span class="sorttext">D+1</span></td>
+<td style="background:#B0CEFF">(<span style="display:none;" class="sortkey">099 !</span><span class="sorttext"><a href="/wiki/Maggie_Hassan" title="Maggie Hassan">Maggie Hassan</a></span>) (D)</td>
+<td style="background:#B0CEFF">52.6% D</td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#ddf"><span style="display:none;" class="sortkey">099 !</span><span class="sorttext">Tilt D</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff">TBD</td>
+</tr>
+<tr>
+<th style="background:#FFB6B6"><a href="#North_Carolina">North Carolina</a></th>
+<td style="background:#fcc"><span style="display:none;" class="sortkey">103 !</span><span class="sorttext">R+3</span></td>
+<td style="background:#FFB6B6"><span style="display:none;" class="sortkey">101 !</span><span class="sorttext"><a href="/wiki/Pat_McCrory" title="Pat McCrory">Pat McCrory</a></span> (R)</td>
+<td style="background:#FFB6B6">54.7% R</td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#ccf"><span style="display:none;" class="sortkey">098 !</span><span class="sorttext">Lean D</span></td>
+<td style="background:#fff"></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff">TBD</td>
+</tr>
+<tr>
+<th style="background:#FFB6B6"><a href="#North_Dakota">North Dakota</a></th>
+<td style="background:#f66"><span style="display:none;" class="sortkey">110 !</span><span class="sorttext">R+10</span></td>
+<td style="background:#FFB6B6"><span style="display:none;" class="sortkey">101 !</span><span class="sorttext">(<a href="/wiki/Jack_Dalrymple" title="Jack Dalrymple">Jack Dalrymple</a>)</span> (R)</td>
+<td style="background:#FFB6B6">63.1% R</td>
+<td style="background:#f66"><span style="display:none;" class="sortkey">104 !</span><span class="sorttext">Safe R</span></td>
+<td style="background:#f66"><span style="display:none;" class="sortkey">104 !</span><span class="sorttext">Safe R</span></td>
+<td style="background:#f66"><span style="display:none;" class="sortkey">104 !</span><span class="sorttext">Safe R</span></td>
+<td style="background:#f66"><span style="display:none;" class="sortkey">104 !</span><span class="sorttext">Safe R</span></td>
+<td style="background:#fff"></td>
+<td style="background:#f66"><span style="display:none;" class="sortkey">104 !</span><span class="sorttext">Safe R</span></td>
+<td style="background:#fff">TBD</td>
+</tr>
+<tr>
+<th style="background:#B0CEFF"><a href="#Oregon">Oregon</a></th>
+<td style="background:#99f"><span style="display:none;" class="sortkey">096 !</span><span class="sorttext">D+5</span></td>
+<td style="background:#B0CEFF"><span style="display:none;" class="sortkey">099 !</span><span class="sorttext"><a href="/wiki/Kate_Brown" title="Kate Brown">Kate Brown</a></span> (D)</td>
+<td style="background:#B0CEFF">49.5% D</td>
+<td style="background:#99f"><span style="display:none;" class="sortkey">097 !</span><span class="sorttext">Likely D</span></td>
+<td style="background:#99f"><span style="display:none;" class="sortkey">097 !</span><span class="sorttext">Likely D</span></td>
+<td style="background:#66f"><span style="display:none;" class="sortkey">096 !</span><span class="sorttext">Safe D</span></td>
+<td style="background:#66f"><span style="display:none;" class="sortkey">096 !</span><span class="sorttext">Safe D</span></td>
+<td></td>
+<td style="background:#66f"><span style="display:none;" class="sortkey">096 !</span><span class="sorttext">Safe D</span></td>
+<td style="background:#fff">TBD</td>
+</tr>
+<tr>
+<th style="background:#FFB6B6"><a href="#Utah">Utah</a></th>
+<td style="background:#f66"><span style="display:none;" class="sortkey">122 !</span><span class="sorttext">R+22</span></td>
+<td style="background:#FFB6B6"><span style="display:none;" class="sortkey">101 !</span><span class="sorttext"><a href="/wiki/Gary_Herbert" title="Gary Herbert">Gary Herbert</a></span> (R)</td>
+<td style="background:#FFB6B6">68.3% R</td>
+<td style="background:#f66"><span style="display:none;" class="sortkey">104 !</span><span class="sorttext">Safe R</span></td>
+<td style="background:#f66"><span style="display:none;" class="sortkey">104 !</span><span class="sorttext">Safe R</span></td>
+<td style="background:#f66"><span style="display:none;" class="sortkey">104 !</span><span class="sorttext">Safe R</span></td>
+<td style="background:#f66"><span style="display:none;" class="sortkey">104 !</span><span class="sorttext">Safe R</span></td>
+<td style="background:#fff"></td>
+<td style="background:#f66"><span style="display:none;" class="sortkey">104 !</span><span class="sorttext">Safe R</span></td>
+<td style="background:#fff">TBD</td>
+</tr>
+<tr>
+<th style="background:#B0CEFF"><a href="#Vermont">Vermont</a></th>
+<td style="background:#66f"><span style="display:none;" class="sortkey">092 !</span><span class="sorttext">D+18</span></td>
+<td style="background:#B0CEFF"><span style="display:none;" class="sortkey">099 !</span><span class="sorttext">(<a href="/wiki/Peter_Shumlin" title="Peter Shumlin">Peter Shumlin</a>)</span> (D)</td>
+<td style="background:#B0CEFF">46.4% D</td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#99f"><span style="display:none;" class="sortkey">097 !</span><span class="sorttext">Likely D</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"></td>
+<td style="background:#ddf"><span style="display:none;" class="sortkey">099 !</span><span class="sorttext">Tilt D</span></td>
+<td style="background:#fff">TBD</td>
+</tr>
+<tr>
+<th style="background:#B0CEFF"><a href="#Washington">Washington</a></th>
+<td style="background:#99f"><span style="display:none;" class="sortkey">095 !</span><span class="sorttext">D+5</span></td>
+<td style="background:#B0CEFF"><span style="display:none;" class="sortkey">099 !</span><span class="sorttext"><a href="/wiki/Jay_Inslee" title="Jay Inslee">Jay Inslee</a></span> (D)</td>
+<td style="background:#B0CEFF">51.5% D</td>
+<td style="background:#66f"><span style="display:none;" class="sortkey">096 !</span><span class="sorttext">Safe D</span></td>
+<td style="background:#99f"><span style="display:none;" class="sortkey">097 !</span><span class="sorttext">Likely D</span></td>
+<td style="background:#66f"><span style="display:none;" class="sortkey">096 !</span><span class="sorttext">Safe D</span></td>
+<td style="background:#66f"><span style="display:none;" class="sortkey">096 !</span><span class="sorttext">Safe D</span></td>
+<td style="background:#fff"></td>
+<td style="background:#66f"><span style="display:none;" class="sortkey">096 !</span><span class="sorttext">Safe D</span></td>
+<td style="background:#fff">TBD</td>
+</tr>
+<tr>
+<th style="background:#FFB6B6"><a href="#West_Virginia">West Virginia</a></th>
+<td style="background:#f66"><span style="display:none;" class="sortkey">113 !</span><span class="sorttext">R+13</span></td>
+<td style="background:#B0CEFF"><span style="display:none;" class="sortkey">098 !</span><span class="sorttext">(<a href="/wiki/Earl_Ray_Tomblin" title="Earl Ray Tomblin">Earl Ray Tomblin</a>)</span> (D)</td>
+<td style="background:#B0CEFF">50.4% D</td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff"></td>
+<td style="background:#fff"><span style="display:none;" class="sortkey">100 !</span><span class="sorttext">Tossup</span></td>
+<td style="background:#fff">TBD</td>
+</tr>
+</table>
+<h2><span class="mw-headline" id="Primary_dates">Primary dates</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=2" title="Edit section: Primary dates">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>This table shows the primary dates for regularly-scheduled elections. It also shows the <a href="/wiki/Primary_elections_in_the_United_States" title="Primary elections in the United States">type of primary</a>. In an "open" primary, any registered voter can vote in any party's primary. In a "closed" primary, only voters registered with a specific party can vote in that party's primary. In a "<a href="/wiki/Nonpartisan_blanket_primary" title="Nonpartisan blanket primary">top-two</a>" primary, all candidates run against each other regardless of party affiliation, and the top two candidates advance to the second round of voting (in Louisiana, a candidate can win the election by winning a majority of the vote in the first round). All other primary types are classified as "hybrid."</p>
+<table class="wikitable">
+<tr>
+<th colspan="3">March–May</th>
+<th colspan="3">June</th>
+<th colspan="3">August</th>
+<th colspan="3">September</th>
+</tr>
+<tr>
+<th>State</th>
+<th>Date<sup id="cite_ref-FEC_6-0" class="reference"><a href="#cite_note-FEC-6">[6]</a></sup></th>
+<th>Type<sup id="cite_ref-primarytypes_7-0" class="reference"><a href="#cite_note-primarytypes-7">[7]</a></sup></th>
+<th>State</th>
+<th>Date</th>
+<th>Type</th>
+<th>State</th>
+<th>Date</th>
+<th>Type</th>
+<th>State</th>
+<th>Date</th>
+<th>Type</th>
+</tr>
+<tr>
+<th>North Carolina</th>
+<td>Mar. 15</td>
+<td>Hybrid</td>
+<th>Montana</th>
+<td>Jun. 7</td>
+<td>Open</td>
+<th>Missouri</th>
+<td>Aug. 2</td>
+<td>Closed</td>
+<th>Delaware</th>
+<td>Sep. 13</td>
+<td>Closed</td>
+</tr>
+<tr>
+<th>Indiana</th>
+<td>May 3</td>
+<td>Open</td>
+<th>North Dakota</th>
+<td>June 14</td>
+<td>Hybrid</td>
+<th>Washington</th>
+<td>Aug. 2</td>
+<td>Top-two</td>
+<th>New Hampshire</th>
+<td>Sep. 13</td>
+<td>Closed</td>
+</tr>
+<tr>
+<th>West Virginia</th>
+<td>May 10</td>
+<td>Open</td>
+<th>Utah</th>
+<td>June 28</td>
+<td>Open</td>
+<th>Vermont</th>
+<td>Aug. 9</td>
+<td>Open</td>
+</tr>
+<tr>
+<th>Oregon</th>
+<td>May 17</td>
+<td>Closed</td>
+</tr>
+</table>
+<h2><span class="mw-headline" id="Race_Summary">Race Summary</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=3" title="Edit section: Race Summary">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<h3><span class="mw-headline" id="States">States</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=4" title="Edit section: States">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<table class="wikitable sortable">
+<tr valign="bottom">
+<th colspan="2">State</th>
+<th colspan="4">Incumbent</th>
+<th colspan="2">This race</th>
+</tr>
+<tr valign="bottom">
+<th>State</th>
+<th><a href="/wiki/Cook_PVI" class="mw-redirect" title="Cook PVI">PVI</a></th>
+<th>Governor</th>
+<th>Party</th>
+<th>First<br />
+elected</th>
+<th>Status</th>
+<th>Candidates</th>
+</tr>
+<tr>
+<th><a href="/wiki/Delaware" title="Delaware">Delaware</a></th>
+<td style="background:#B0CEFF"><span style="display:none;" class="sortkey">115 !</span><span class="sorttext">D+8</span></td>
+<td><a href="/wiki/Jack_Markell" title="Jack Markell">Jack Markell</a></td>
+<td style="background:#B0CEFF">Democratic</td>
+<td><a href="/wiki/Delaware_gubernatorial_election,_2008" title="Delaware gubernatorial election, 2008">2008</a></td>
+<td>Term limited</td>
+<td><a href="/wiki/Colin_Bonini" title="Colin Bonini">Colin Bonini</a> (Republican)<sup id="cite_ref-8" class="reference"><a href="#cite_note-8">[8]</a></sup><br />
+<a href="/wiki/John_Carney_(politician)" title="John Carney (politician)">John Carney</a> (Democratic)<sup id="cite_ref-9" class="reference"><a href="#cite_note-9">[9]</a></sup><br />
+Sean Goward (Libertarian)<sup id="cite_ref-lp.org_10-0" class="reference"><a href="#cite_note-lp.org-10">[10]</a></sup></td>
+</tr>
+<tr>
+<th><a href="/wiki/Indiana" title="Indiana">Indiana</a></th>
+<td style="background:#FFB6B6"><span style="display:none;" class="sortkey">115 !</span><span class="sorttext">R+5</span></td>
+<td><a href="/wiki/Mike_Pence" title="Mike Pence">Mike Pence</a></td>
+<td style="background:#FFB6B6">Republican</td>
+<td><a href="/wiki/Indiana_gubernatorial_election,_2012" title="Indiana gubernatorial election, 2012">2012</a></td>
+<td>Retiring; Running for Vice President<sup id="cite_ref-nbcnews.com_11-0" class="reference"><a href="#cite_note-nbcnews.com-11">[11]</a></sup></td>
+<td><a href="/wiki/John_R._Gregg" title="John R. Gregg">John Gregg</a> (Democratic)<sup id="cite_ref-12" class="reference"><a href="#cite_note-12">[12]</a></sup><br />
+<a href="/wiki/Eric_Holcomb" title="Eric Holcomb">Eric Holcomb</a> (Republican)<sup id="cite_ref-13" class="reference"><a href="#cite_note-13">[13]</a></sup><br />
+Rex Bell (Libertarian)<sup id="cite_ref-14" class="reference"><a href="#cite_note-14">[14]</a></sup></td>
+</tr>
+<tr>
+<th><a href="/wiki/Missouri" title="Missouri">Missouri</a></th>
+<td style="background:#FFB6B6"><span style="display:none;" class="sortkey">115 !</span><span class="sorttext">R+5</span></td>
+<td><a href="/wiki/Jay_Nixon" title="Jay Nixon">Jay Nixon</a></td>
+<td style="background:#B0CEFF">Democratic</td>
+<td><a href="/wiki/Missouri_gubernatorial_election,_2008" title="Missouri gubernatorial election, 2008">2008</a></td>
+<td>Term limited</td>
+<td><a href="/wiki/Eric_Greitens" title="Eric Greitens">Eric Greitens</a> (Republican)<sup id="cite_ref-15" class="reference"><a href="#cite_note-15">[15]</a></sup><br />
+<a href="/wiki/Chris_Koster" title="Chris Koster">Chris Koster</a> (Democratic)<sup id="cite_ref-16" class="reference"><a href="#cite_note-16">[16]</a></sup><br />
+Cisse Spragins (Libertarian)<sup id="cite_ref-lp.org_10-1" class="reference"><a href="#cite_note-lp.org-10">[10]</a></sup></td>
+</tr>
+<tr>
+<th><a href="/wiki/Montana" title="Montana">Montana</a></th>
+<td style="background:#FFB6B6"><span style="display:none;" class="sortkey">117 !</span><span class="sorttext">R+7</span></td>
+<td><a href="/wiki/Steve_Bullock_(Montana_politician)" title="Steve Bullock (Montana politician)">Steve Bullock</a></td>
+<td style="background:#B0CEFF">Democratic</td>
+<td><a href="/wiki/Montana_gubernatorial_election,_2012" title="Montana gubernatorial election, 2012">2012</a></td>
+<td>Running</td>
+<td><a href="/wiki/Steve_Bullock_(Montana_politician)" title="Steve Bullock (Montana politician)">Steve Bullock</a> (Democratic)<sup id="cite_ref-17" class="reference"><a href="#cite_note-17">[17]</a></sup><br />
+<a href="/wiki/Greg_Gianforte" title="Greg Gianforte">Greg Gianforte</a> (Republican)<sup id="cite_ref-18" class="reference"><a href="#cite_note-18">[18]</a></sup><br />
+Ted Dunlap (Libertarian)<sup id="cite_ref-19" class="reference"><a href="#cite_note-19">[19]</a></sup></td>
+</tr>
+<tr>
+<th><a href="/wiki/New_Hampshire" title="New Hampshire">New Hampshire</a></th>
+<td style="background:#B0CEFF"><span style="display:none;" class="sortkey">111 !</span><span class="sorttext">D+1</span></td>
+<td><a href="/wiki/Maggie_Hassan" title="Maggie Hassan">Maggie Hassan</a></td>
+<td style="background:#B0CEFF">Democratic</td>
+<td><a href="/wiki/New_Hampshire_gubernatorial_election,_2012" title="New Hampshire gubernatorial election, 2012">2012</a></td>
+<td>Retiring; running for Senate</td>
+<td><a href="/wiki/Chris_Sununu" title="Chris Sununu">Chris Sununu</a> (Republican)<sup id="cite_ref-20" class="reference"><a href="#cite_note-20">[20]</a></sup><br />
+<a href="/wiki/Colin_Van_Ostern" title="Colin Van Ostern">Colin Van Ostern</a> (Democratic)<sup id="cite_ref-21" class="reference"><a href="#cite_note-21">[21]</a></sup><br />
+Max Ambramson (Libertarian)<sup id="cite_ref-lp.org_10-2" class="reference"><a href="#cite_note-lp.org-10">[10]</a></sup></td>
+</tr>
+<tr>
+<th><a href="/wiki/North_Carolina" title="North Carolina">North Carolina</a></th>
+<td style="background:#FFB6B6"><span style="display:none;" class="sortkey">113 !</span><span class="sorttext">R+3</span></td>
+<td><a href="/wiki/Pat_McCrory" title="Pat McCrory">Pat McCrory</a></td>
+<td style="background:#FFB6B6">Republican</td>
+<td><a href="/wiki/North_Carolina_gubernatorial_election,_2012" title="North Carolina gubernatorial election, 2012">2012</a></td>
+<td>Running</td>
+<td><a href="/wiki/Roy_Cooper" title="Roy Cooper">Roy Cooper</a> (Democratic)<sup id="cite_ref-22" class="reference"><a href="#cite_note-22">[22]</a></sup><br />
+<a href="/wiki/Pat_McCrory" title="Pat McCrory">Pat McCrory</a> (Republican)<sup id="cite_ref-23" class="reference"><a href="#cite_note-23">[23]</a></sup><br />
+Lon Cecil (Libertarian)<sup id="cite_ref-lp.org_10-3" class="reference"><a href="#cite_note-lp.org-10">[10]</a></sup></td>
+</tr>
+<tr>
+<th><a href="/wiki/North_Dakota" title="North Dakota">North Dakota</a></th>
+<td style="background:#FFB6B6"><span style="display:none;" class="sortkey">120 !</span><span class="sorttext">R+10</span></td>
+<td><a href="/wiki/Jack_Dalrymple" title="Jack Dalrymple">Jack Dalrymple</a></td>
+<td style="background:#FFB6B6">Republican</td>
+<td><a href="/wiki/North_Dakota_gubernatorial_election,_2012" title="North Dakota gubernatorial election, 2012">2012</a></td>
+<td>Retiring</td>
+<td><a href="/wiki/Doug_Burgum" title="Doug Burgum">Doug Burgum</a> (Republican)<sup id="cite_ref-24" class="reference"><a href="#cite_note-24">[24]</a></sup><br />
+<a href="/wiki/Marvin_Nelson" title="Marvin Nelson">Marvin Nelson</a> (Democratic)<sup id="cite_ref-Inforum_25-0" class="reference"><a href="#cite_note-Inforum-25">[25]</a></sup><br />
+Marty Riske (Libertarian)<sup id="cite_ref-lp.org_10-4" class="reference"><a href="#cite_note-lp.org-10">[10]</a></sup></td>
+</tr>
+<tr>
+<th><a href="/wiki/Oregon" title="Oregon">Oregon</a></th>
+<td style="background:#B0CEFF"><span style="display:none;" class="sortkey">115 !</span><span class="sorttext">D+5</span></td>
+<td><a href="/wiki/Kate_Brown" title="Kate Brown">Kate Brown</a></td>
+<td style="background:#B0CEFF">Democratic</td>
+<td>2015<sup id="cite_ref-26" class="reference"><a href="#cite_note-26">[26]</a></sup></td>
+<td>Running</td>
+<td><a href="/wiki/Kate_Brown" title="Kate Brown">Kate Brown</a> (Democratic)<sup id="cite_ref-27" class="reference"><a href="#cite_note-27">[27]</a></sup><br />
+<a href="/wiki/Bud_Pierce" title="Bud Pierce">Bud Pierce</a> (Republican)<sup id="cite_ref-28" class="reference"><a href="#cite_note-28">[28]</a></sup></td>
+</tr>
+<tr>
+<th><a href="/wiki/Utah" title="Utah">Utah</a></th>
+<td style="background:#FFB6B6"><span style="display:none;" class="sortkey">118 !</span><span class="sorttext">R+22</span></td>
+<td><a href="/wiki/Gary_Herbert" title="Gary Herbert">Gary Herbert</a></td>
+<td style="background:#FFB6B6">Republican</td>
+<td><a href="/wiki/Utah_gubernatorial_special_election,_2010" title="Utah gubernatorial special election, 2010">2010</a></td>
+<td>Running</td>
+<td><a href="/wiki/Gary_Herbert" title="Gary Herbert">Gary Herbert</a> (Republican)<sup id="cite_ref-29" class="reference"><a href="#cite_note-29">[29]</a></sup><br />
+<a href="/wiki/Mike_Weinholtz" title="Mike Weinholtz">Mike Weinholtz</a> (Democratic)<sup id="cite_ref-30" class="reference"><a href="#cite_note-30">[30]</a></sup><br />
+Brian Kamerath (Libertarian)<sup id="cite_ref-lp.org_10-5" class="reference"><a href="#cite_note-lp.org-10">[10]</a></sup></td>
+</tr>
+<tr>
+<th><a href="/wiki/Vermont" title="Vermont">Vermont</a></th>
+<td style="background:#B0CEFF"><span style="display:none;" class="sortkey">118 !</span><span class="sorttext">D+18</span></td>
+<td><a href="/wiki/Peter_Shumlin" title="Peter Shumlin">Peter Shumlin</a></td>
+<td style="background:#B0CEFF">Democratic</td>
+<td><a href="/wiki/Vermont_gubernatorial_election,_2010" title="Vermont gubernatorial election, 2010">2010</a></td>
+<td>Retiring</td>
+<td><a href="/wiki/Sue_Minter" title="Sue Minter">Sue Minter</a> (Democratic)<sup id="cite_ref-31" class="reference"><a href="#cite_note-31">[31]</a></sup><br />
+<a href="/wiki/Phil_Scott_(politician)" title="Phil Scott (politician)">Phil Scott</a> (Republican)<sup id="cite_ref-32" class="reference"><a href="#cite_note-32">[32]</a></sup></td>
+</tr>
+<tr>
+<th><a href="/wiki/Washington_(state)" title="Washington (state)">Washington</a></th>
+<td style="background:#B0CEFF"><span style="display:none;" class="sortkey">115 !</span><span class="sorttext">D+5</span></td>
+<td><a href="/wiki/Jay_Inslee" title="Jay Inslee">Jay Inslee</a></td>
+<td style="background:#B0CEFF">Democratic</td>
+<td><a href="/wiki/Washington_gubernatorial_election,_2012" title="Washington gubernatorial election, 2012">2012</a></td>
+<td>Running</td>
+<td>Bill Bryant (Republican)<sup id="cite_ref-33" class="reference"><a href="#cite_note-33">[33]</a></sup><br />
+<a href="/wiki/Jay_Inslee" title="Jay Inslee">Jay Inslee</a> (Democratic)<sup id="cite_ref-34" class="reference"><a href="#cite_note-34">[34]</a></sup></td>
+</tr>
+<tr>
+<th><a href="/wiki/West_Virginia" title="West Virginia">West Virginia</a></th>
+<td style="background:#FFB6B6"><span style="display:none;" class="sortkey">113 !</span><span class="sorttext">R+13</span></td>
+<td><a href="/wiki/Earl_Ray_Tomblin" title="Earl Ray Tomblin">Earl Ray Tomblin</a></td>
+<td style="background:#B0CEFF">Democratic</td>
+<td><a href="/wiki/West_Virginia_gubernatorial_special_election,_2011" title="West Virginia gubernatorial special election, 2011">2011</a></td>
+<td>Term limited</td>
+<td><a href="/wiki/Bill_Cole_(politician)" title="Bill Cole (politician)">Bill Cole</a> (Republican)<sup id="cite_ref-35" class="reference"><a href="#cite_note-35">[35]</a></sup><br />
+<a href="/wiki/Jim_Justice" title="Jim Justice">Jim Justice</a> (Democratic)<sup id="cite_ref-36" class="reference"><a href="#cite_note-36">[36]</a></sup><br />
+David Moran (Libertarian)<sup id="cite_ref-lp.org_10-6" class="reference"><a href="#cite_note-lp.org-10">[10]</a></sup><br />
+Charlotte Pritt (Green)<sup id="cite_ref-37" class="reference"><a href="#cite_note-37">[37]</a></sup></td>
+</tr>
+</table>
+<h3><span class="mw-headline" id="Territories">Territories</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=5" title="Edit section: Territories">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<table class="wikitable">
+<tr>
+<th>State</th>
+<th>Incumbent</th>
+<th>Party</th>
+<th>First elected</th>
+<th>Incumbent Status</th>
+<th>Candidates</th>
+</tr>
+<tr>
+<td><a href="/wiki/American_Samoa_gubernatorial_election,_2016" class="mw-redirect" title="American Samoa gubernatorial election, 2016">American Samoa</a></td>
+<td style="background:#B0CEFF"><a href="/wiki/Lolo_Matalasi_Moliga" title="Lolo Matalasi Moliga">Lolo Matalasi Moliga</a></td>
+<td style="background:#B0CEFF">Democratic</td>
+<td><a href="/wiki/American_Samoa_gubernatorial_election,_2012" title="American Samoa gubernatorial election, 2012">2012</a></td>
+<td>Unknown</td>
+<td></td>
+</tr>
+<tr>
+<td><a href="/wiki/Puerto_Rico_gubernatorial_election,_2016" title="Puerto Rico gubernatorial election, 2016">Puerto Rico</a></td>
+<td style="background-color:#FFE8E8"><a href="/wiki/Alejandro_Garc%C3%ADa_Padilla" title="Alejandro García Padilla">Alejandro García Padilla</a></td>
+<td style="background-color:#FFE8E8"><a href="/wiki/Popular_Democratic_Party_(Puerto_Rico)" title="Popular Democratic Party (Puerto Rico)">PPD</a></td>
+<td><a href="/wiki/Puerto_Rico_gubernatorial_election,_2012" title="Puerto Rico gubernatorial election, 2012">2012</a></td>
+<td>Retiring</td>
+<td><a href="/wiki/David_Bernier" title="David Bernier">David Bernier</a> (<a href="/wiki/Popular_Democratic_Party_of_Puerto_Rico" class="mw-redirect" title="Popular Democratic Party of Puerto Rico">PPD</a>)<br />
+<a href="/wiki/Ricky_Rossell%C3%B3" title="Ricky Rosselló">Ricky Rosselló</a> (<a href="/wiki/New_Progressive_Party_of_Puerto_Rico" title="New Progressive Party of Puerto Rico">PNP</a>)<br />
+<a href="/wiki/Mar%C3%ADa_de_Lourdes_Santiago" title="María de Lourdes Santiago">María de Lourdes Santiago</a> (<a href="/wiki/Puerto_Rican_Independence_Party" title="Puerto Rican Independence Party">PIP</a>)<br />
+<a href="/w/index.php?title=Rafael_Bernabe&amp;action=edit&amp;redlink=1" class="new" title="Rafael Bernabe (page does not exist)">Rafael Bernabe</a> (<a href="/wiki/Working_People%27s_Party_of_Puerto_Rico" title="Working People's Party of Puerto Rico">PPT</a>)<br />
+<a href="/wiki/Alexandra_L%C3%BAgaro" title="Alexandra Lúgaro">Alexandra Lúgaro</a> (Independent)<br />
+<a href="/wiki/Manuel_Cidre" title="Manuel Cidre">Manuel Cidre</a> (Independent)</td>
+</tr>
+</table>
+<h2><span class="mw-headline" id="Partisan_control_of_states">Partisan control of states</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=6" title="Edit section: Partisan control of states">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<div role="note" class="hatnote">See also: <a href="/wiki/Political_party_strength_in_U.S._states" title="Political party strength in U.S. states">Political party strength in U.S. states</a></div>
+<p>All of the states holding gubernatorial elections in 2016 are also holding state legislative elections in 2016, although some legislative seats are not up for election in states that <a href="/wiki/Staggered_elections" title="Staggered elections">stagger</a> legislative elections.<sup id="cite_ref-ncsl2_38-0" class="reference"><a href="#cite_note-ncsl2-38">[38]</a></sup></p>
+<table class="wikitable sortable">
+<tr>
+<th></th>
+<th colspan="3">Before election<sup id="cite_ref-ncsl_39-0" class="reference"><a href="#cite_note-ncsl-39">[39]</a></sup></th>
+<th colspan="3">After election</th>
+</tr>
+<tr>
+<th>State</th>
+<th>Governor</th>
+<th>Senate</th>
+<th>House</th>
+<th>Governor</th>
+<th>Senate</th>
+<th>House</th>
+</tr>
+<tr>
+<th>Delaware</th>
+<td style="background:#B0CEFF">Dem</td>
+<td style="background:#B0CEFF">Dem</td>
+<td style="background:#B0CEFF">Dem</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<th>Indiana</th>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#FFB6B6">Rep</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<th>Missouri</th>
+<td style="background:#B0CEFF">Dem</td>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#FFB6B6">Rep</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<th>Montana</th>
+<td style="background:#B0CEFF">Dem</td>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#FFB6B6">Rep</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<th>New Hampshire</th>
+<td style="background:#B0CEFF">Dem</td>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#FFB6B6">Rep</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<th>North Carolina</th>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#FFB6B6">Rep</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<th>North Dakota</th>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#FFB6B6">Rep</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<th>Oregon</th>
+<td style="background:#B0CEFF">Dem</td>
+<td style="background:#B0CEFF">Dem</td>
+<td style="background:#B0CEFF">Dem</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<th>Utah</th>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#FFB6B6">Rep</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<th>Vermont</th>
+<td style="background:#B0CEFF">Dem</td>
+<td style="background:#B0CEFF">Dem</td>
+<td style="background:#B0CEFF">Dem</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<th>Washington</th>
+<td style="background:#B0CEFF">Dem</td>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#B0CEFF">Dem</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<th>West Virginia</th>
+<td style="background:#B0CEFF">Dem</td>
+<td style="background:#FFB6B6">Rep</td>
+<td style="background:#FFB6B6">Rep</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<h2><span class="mw-headline" id="Retiring_and_term-limited_Democratic_incumbents">Retiring and term-limited Democratic incumbents</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=7" title="Edit section: Retiring and term-limited Democratic incumbents">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<h3><span class="mw-headline" id="Jack_Markell_.28Delaware.29">Jack Markell (Delaware)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=8" title="Edit section: Jack Markell (Delaware)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/Delaware_gubernatorial_election,_2016" title="Delaware gubernatorial election, 2016">Delaware gubernatorial election, 2016</a></div>
+<p>Two-term incumbent <a href="/wiki/Governor_of_Delaware" class="mw-redirect" title="Governor of Delaware">Governor</a> <a href="/wiki/Jack_Markell" title="Jack Markell">Jack Markell</a> is term-limited in 2016.<sup id="cite_ref-40" class="reference"><a href="#cite_note-40">[40]</a></sup> Former Democratic <a href="/wiki/Delaware_Attorney_General" class="mw-redirect" title="Delaware Attorney General">Delaware Attorney General</a> <a href="/wiki/Beau_Biden" title="Beau Biden">Beau Biden</a>, the son of <a href="/wiki/Vice_President_of_the_United_States" title="Vice President of the United States">Vice President</a> <a href="/wiki/Joe_Biden" title="Joe Biden">Joe Biden</a>, announced his intention to run and was seen as the front-runner in the Democratic primary and general election, but he died of brain cancer at the age of 46 on May 30, 2015.<sup id="cite_ref-41" class="reference"><a href="#cite_note-41">[41]</a></sup><sup id="cite_ref-42" class="reference"><a href="#cite_note-42">[42]</a></sup> Congressman <a href="/wiki/John_Carney_(politician)" title="John Carney (politician)">John Carney</a>, a former <a href="/wiki/Lieutenant_Governor_of_Delaware" title="Lieutenant Governor of Delaware">Lieutenant Governor of Delaware</a> who ran for governor <a href="/wiki/Delaware_gubernatorial_election,_2008" title="Delaware gubernatorial election, 2008">in 2008</a>, is seeking the Democratic nomination.<sup id="cite_ref-43" class="reference"><a href="#cite_note-43">[43]</a></sup> State Representative <a href="/wiki/Michael_Ramone" title="Michael Ramone">Michael Ramone</a> is a possible candidate for the Republicans.<sup id="cite_ref-Biden_44-0" class="reference"><a href="#cite_note-Biden-44">[44]</a></sup></p>
+<h3><span class="mw-headline" id="Jay_Nixon_.28Missouri.29">Jay Nixon (Missouri)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=9" title="Edit section: Jay Nixon (Missouri)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/Missouri_gubernatorial_election,_2016" title="Missouri gubernatorial election, 2016">Missouri gubernatorial election, 2016</a></div>
+<p>Two-term incumbent <a href="/wiki/Governor_of_Missouri" class="mw-redirect" title="Governor of Missouri">Governor</a> <a href="/wiki/Jay_Nixon" title="Jay Nixon">Jay Nixon</a> is term-limited in 2016.<sup id="cite_ref-Nixon_term_limits_45-0" class="reference"><a href="#cite_note-Nixon_term_limits-45">[45]</a></sup></p>
+<p><a href="/wiki/Missouri_Attorney_General" title="Missouri Attorney General">Missouri Attorney General</a> <a href="/wiki/Chris_Koster" title="Chris Koster">Chris Koster</a> is running for the Democratic nomination.<sup id="cite_ref-46" class="reference"><a href="#cite_note-46">[46]</a></sup> U.S. Senator and <a href="/wiki/Missouri_gubernatorial_election,_2004" title="Missouri gubernatorial election, 2004">2004</a> gubernatorial nominee <a href="/wiki/Claire_McCaskill" title="Claire McCaskill">Claire McCaskill</a><sup id="cite_ref-47" class="reference"><a href="#cite_note-47">[47]</a></sup> and <a href="/wiki/State_Treasurer_of_Missouri" title="State Treasurer of Missouri">State Treasurer</a> <a href="/wiki/Clint_Zweifel" title="Clint Zweifel">Clint Zweifel</a> declined to run for governor.<sup id="cite_ref-48" class="reference"><a href="#cite_note-48">[48]</a></sup> On August 3, 2016, Koster formally won the nomination with a dominating 79% of the primary vote.<sup id="cite_ref-auto_49-0" class="reference"><a href="#cite_note-auto-49">[49]</a></sup></p>
+<p>Former <a href="/wiki/Speaker_of_the_Missouri_House_of_Representatives" title="Speaker of the Missouri House of Representatives">Speaker</a> of the <a href="/wiki/Missouri_House_of_Representatives" title="Missouri House of Representatives">Missouri House of Representatives</a> <a href="/wiki/Catherine_Hanaway" title="Catherine Hanaway">Catherine Hanaway</a>, businessman <a href="/w/index.php?title=John_G._Brunner&amp;action=edit&amp;redlink=1" class="new" title="John G. Brunner (page does not exist)">John Brunner</a>, State Senator <a href="/wiki/Bob_Dixon_(Missouri_politician)" title="Bob Dixon (Missouri politician)">Bob Dixon</a>, former Navy SEAL <a href="/wiki/Eric_Greitens" title="Eric Greitens">Eric Greitens</a>, and <a href="/wiki/Lieutenant_Governor_of_Missouri" class="mw-redirect" title="Lieutenant Governor of Missouri">Lieutenant Governor</a> <a href="/wiki/Peter_Kinder" title="Peter Kinder">Peter Kinder</a> are running for the Republican nomination.<sup id="cite_ref-50" class="reference"><a href="#cite_note-50">[50]</a></sup> State Representative Bart Korman and U.S. Representative <a href="/wiki/Blaine_Luetkemeyer" title="Blaine Luetkemeyer">Blaine Luetkemeyer</a><sup id="cite_ref-51" class="reference"><a href="#cite_note-51">[51]</a></sup><sup id="cite_ref-52" class="reference"><a href="#cite_note-52">[52]</a></sup><sup id="cite_ref-53" class="reference"><a href="#cite_note-53">[53]</a></sup> declined to run for governor. Former Missouri Auditor <a href="/wiki/Tom_Schweich" title="Tom Schweich">Tom Schweich</a> had been a candidate for governor before he committed suicide in February 2015.<sup id="cite_ref-54" class="reference"><a href="#cite_note-54">[54]</a></sup> On August 3, 2016, Grietens formally won the nomination with 35% of the vote.<sup id="cite_ref-auto_49-1" class="reference"><a href="#cite_note-auto-49">[49]</a></sup></p>
+<h3><span class="mw-headline" id="Maggie_Hassan_.28New_Hampshire.29">Maggie Hassan (New Hampshire)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=10" title="Edit section: Maggie Hassan (New Hampshire)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/New_Hampshire_gubernatorial_election,_2016" title="New Hampshire gubernatorial election, 2016">New Hampshire gubernatorial election, 2016</a></div>
+<p>Two-term incumbent <a href="/wiki/Governor_of_New_Hampshire" title="Governor of New Hampshire">Governor</a> <a href="/wiki/Maggie_Hassan" title="Maggie Hassan">Maggie Hassan</a> is <a href="/wiki/United_States_Senate_election_in_New_Hampshire,_2016" title="United States Senate election in New Hampshire, 2016">running for the U.S. Senate</a>. She won a second term in <a href="/wiki/New_Hampshire_gubernatorial_election,_2014" title="New Hampshire gubernatorial election, 2014">2014</a> with 53% of the vote against Republican businessman <a href="/wiki/Walt_Havenstein" title="Walt Havenstein">Walt Havenstein</a>.</p>
+<p><a href="/wiki/Executive_Council_of_New_Hampshire" title="Executive Council of New Hampshire">Executive Councilor</a> <a href="/wiki/Colin_Van_Ostern" title="Colin Van Ostern">Colin Van Ostern</a> and former Deputy Secretary of State and Director of Securities Regulation <a href="/wiki/Mark_Connolly_(public_official)" title="Mark Connolly (public official)">Mark Connolly</a> are running for the Democratic nomination. State Senator <a href="/wiki/Donna_Soucy" title="Donna Soucy">Donna Soucy</a> is a possible Democratic candidate.<sup id="cite_ref-16in16_55-0" class="reference"><a href="#cite_note-16in16-55">[55]</a></sup></p>
+<p>Executive Councilor <a href="/wiki/Christopher_Sununu" class="mw-redirect" title="Christopher Sununu">Christopher Sununu</a>, State Representative and entrepreneur Frank Edelblut, and Jon Lavoie are running for the Republican nomination.<sup id="cite_ref-56" class="reference"><a href="#cite_note-56">[56]</a></sup> <a href="/wiki/Nashua,_New_Hampshire" title="Nashua, New Hampshire">Nashua</a> Mayor <a href="/wiki/Donnalee_Lozeau" title="Donnalee Lozeau">Donnalee Lozeau</a> may also run for the Republican nomination.<sup id="cite_ref-57" class="reference"><a href="#cite_note-57">[57]</a></sup></p>
+<h3><span class="mw-headline" id="Alejandro_Garc.C3.ADa_Padilla_.28Puerto_Rico.29">Alejandro García Padilla (Puerto Rico)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=11" title="Edit section: Alejandro García Padilla (Puerto Rico)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/Puerto_Rico_gubernatorial_election,_2016" title="Puerto Rico gubernatorial election, 2016">Puerto Rico gubernatorial election, 2016</a></div>
+<p>One-term incumbent <a href="/wiki/Governor_of_Puerto_Rico" title="Governor of Puerto Rico">Governor</a> <a href="/wiki/Alejandro_Garc%C3%ADa_Padilla" title="Alejandro García Padilla">Alejandro García Padilla</a> was eligible to run for re-election, but has chosen to retire.<sup id="cite_ref-58" class="reference"><a href="#cite_note-58">[58]</a></sup> García Padilla is a member of the <a href="/wiki/Popular_Democratic_Party_of_Puerto_Rico" class="mw-redirect" title="Popular Democratic Party of Puerto Rico">Popular Democratic Party</a> (PDP).<sup id="cite_ref-59" class="reference"><a href="#cite_note-59">[59]</a></sup> García Padilla was elected in <a href="/wiki/Puerto_Rico_gubernatorial_election,_2012" title="Puerto Rico gubernatorial election, 2012">2012</a> with 47.73% of the vote.</p>
+<p><a href="/wiki/David_Bernier" title="David Bernier">David Bernier</a>, former <a href="/wiki/Secretary_of_State_of_Puerto_Rico" title="Secretary of State of Puerto Rico">Secretary of State of Puerto Rico</a> and former President of the <a href="/wiki/Puerto_Rico_Olympic_Committee" title="Puerto Rico Olympic Committee">Puerto Rico Olympic Committee</a>, will be seeking the PDP nomination for governor.<sup id="cite_ref-60" class="reference"><a href="#cite_note-60">[60]</a></sup></p>
+<p><a href="/wiki/Resident_Commissioner_of_Puerto_Rico" title="Resident Commissioner of Puerto Rico">Resident Commissioner of Puerto Rico</a> <a href="/wiki/Pedro_Pierluisi" title="Pedro Pierluisi">Pedro Pierluisi</a>, who is affiliated with the <a href="/wiki/New_Progressive_Party_of_Puerto_Rico" title="New Progressive Party of Puerto Rico">New Progressive Party</a> (PNP).<sup id="cite_ref-PierlusiGov_61-0" class="reference"><a href="#cite_note-PierlusiGov-61">[61]</a></sup> and activist, political commentator and son of former governor <a href="/wiki/Pedro_Rossell%C3%B3" title="Pedro Rosselló">Pedro Rosselló</a>, <a href="/wiki/Ricky_Rossell%C3%B3" title="Ricky Rosselló">Ricky Rosselló</a> are seeking the PNP nomination for governor.</p>
+<h3><span class="mw-headline" id="Peter_Shumlin_.28Vermont.29">Peter Shumlin (Vermont)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=12" title="Edit section: Peter Shumlin (Vermont)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/Vermont_gubernatorial_election,_2016" title="Vermont gubernatorial election, 2016">Vermont gubernatorial election, 2016</a></div>
+<p>Three-term incumbent <a href="/wiki/Governor_of_Vermont" title="Governor of Vermont">Governor</a> <a href="/wiki/Peter_Shumlin" title="Peter Shumlin">Peter Shumlin</a> declined to seek re-election.<sup id="cite_ref-62" class="reference"><a href="#cite_note-62">[62]</a></sup> He was re-elected with 46.4% of the vote in <a href="/wiki/Vermont_gubernatorial_election,_2014" title="Vermont gubernatorial election, 2014">2014</a>. As he did not receive a majority of the vote, the <a href="/wiki/Vermont_General_Assembly" title="Vermont General Assembly">Vermont General Assembly</a> was required to choose the winner. The Vermont Assembly chose Shumlin over Republican nominee <a href="/wiki/Scott_Milne" title="Scott Milne">Scott Milne</a> by 110 votes to 69.<sup id="cite_ref-shumlinbeatsmilne_63-0" class="reference"><a href="#cite_note-shumlinbeatsmilne-63">[63]</a></sup></p>
+<p><a href="/wiki/Sue_Minter" title="Sue Minter">Sue Minter</a>, and former state senator <a href="/wiki/Matt_Dunne" title="Matt Dunne">Matt Dunne</a> are running for the Democratic nomination for governor.<sup id="cite_ref-thallenbeck_64-0" class="reference"><a href="#cite_note-thallenbeck-64">[64]</a></sup> House Speaker <a href="/wiki/Shap_Smith" title="Shap Smith">Shap Smith</a> ran, but withdrew. Former lieutenant governor <a href="/wiki/Doug_Racine" title="Doug Racine">Doug Racine</a> declined to run for governor.<sup id="cite_ref-Circus_65-0" class="reference"><a href="#cite_note-Circus-65">[65]</a></sup><sup id="cite_ref-Galloway_66-0" class="reference"><a href="#cite_note-Galloway-66">[66]</a></sup></p>
+<p>Lieutenant Governor <a href="/wiki/Phillip_Scott_(politician)" class="mw-redirect" title="Phillip Scott (politician)">Phil Scott</a> is running for the Republican nomination.<sup id="cite_ref-thallenbeck_64-1" class="reference"><a href="#cite_note-thallenbeck-64">[64]</a></sup> Former state senator and former <a href="/wiki/Vermont_Auditor_of_Accounts" title="Vermont Auditor of Accounts">Vermont Auditor of Accounts</a> <a href="/wiki/Randy_Brock" title="Randy Brock">Randy Brock</a> and 2014 Republican nominee <a href="/wiki/Scott_Milne" title="Scott Milne">Scott Milne</a> declined to run for governor. Former Libertarian gubernatorial candidate Dan Feliciano is a potential candidate.<sup id="cite_ref-Circus_65-1" class="reference"><a href="#cite_note-Circus-65">[65]</a></sup><sup id="cite_ref-Galloway_66-1" class="reference"><a href="#cite_note-Galloway-66">[66]</a></sup></p>
+<p>State Senator, 2000 Progressive gubernatorial nominee, and former Independent gubernatorial candidate <a href="/wiki/Anthony_Pollina" title="Anthony Pollina">Anthony Pollina</a> is running for the Progressive nomination.</p>
+<h3><span class="mw-headline" id="Earl_Ray_Tomblin_.28West_Virginia.29">Earl Ray Tomblin (West Virginia)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=13" title="Edit section: Earl Ray Tomblin (West Virginia)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/West_Virginia_gubernatorial_election,_2016" title="West Virginia gubernatorial election, 2016">West Virginia gubernatorial election, 2016</a></div>
+<p><a href="/wiki/Governor_of_West_Virginia" class="mw-redirect" title="Governor of West Virginia">Governor</a> <a href="/wiki/Earl_Ray_Tomblin" title="Earl Ray Tomblin">Earl Ray Tomblin</a> is term-limited in 2016.<sup id="cite_ref-TomblinTermLimits_67-0" class="reference"><a href="#cite_note-TomblinTermLimits-67">[67]</a></sup> Tomblin was first elected in a <a href="/wiki/West_Virginia_gubernatorial_special_election,_2011" title="West Virginia gubernatorial special election, 2011">2011 special election</a> after <a href="/wiki/Joe_Manchin" title="Joe Manchin">Joe Manchin</a> resigned after being <a href="/wiki/United_States_Senate_special_election_in_West_Virginia,_2010" title="United States Senate special election in West Virginia, 2010">elected to</a> the <a href="/wiki/United_States_Senate" title="United States Senate">United States Senate</a>. Tomblin then won election to a full term in <a href="/wiki/West_Virginia_gubernatorial_election,_2012" title="West Virginia gubernatorial election, 2012">2012</a>.</p>
+<p>Democratic candidates include former U.S. Attorney <a href="/wiki/Booth_Goodwin" title="Booth Goodwin">Booth Goodwin</a>, state Senator <a href="/wiki/Jeff_Kessler" title="Jeff Kessler">Jeff Kessler</a>, and businessman <a href="/wiki/Jim_Justice" title="Jim Justice">Jim Justice</a>. Former Senator <a href="/wiki/Carte_Goodwin" title="Carte Goodwin">Carte Goodwin</a>, former <a href="/wiki/List_of_Speakers_of_the_West_Virginia_House_of_Delegates" title="List of Speakers of the West Virginia House of Delegates">Speaker</a> of the <a href="/wiki/West_Virginia_House_of_Delegates" title="West Virginia House of Delegates">West Virginia House of Delegates</a> <a href="/wiki/Rick_Thompson" title="Rick Thompson">Rick Thompson</a>, West Virginia <a href="/wiki/State_Treasurer" class="mw-redirect" title="State Treasurer">State Treasurer</a> <a href="/wiki/John_Perdue" title="John Perdue">John Perdue</a>, State Senator <a href="/wiki/Mike_Green_(West_Virginia_politician)" title="Mike Green (West Virginia politician)">Mike Green</a> and State Delegates <a href="/wiki/Doug_Reynolds_(West_Virginia)" class="mw-redirect" title="Doug Reynolds (West Virginia)">Doug Reynolds</a>, <a href="/wiki/Doug_Skaff" title="Doug Skaff">Doug Skaff</a> and<a href="/wiki/West_Virginia_Secretary_of_State" class="mw-redirect" title="West Virginia Secretary of State">West Virginia Secretary of State</a> <a href="/wiki/Natalie_Tennant" title="Natalie Tennant">Natalie Tennant</a> declined to seek the nomination. On May 10, 2016, Justice won the Democratic primary and became the nominee.<sup id="cite_ref-68" class="reference"><a href="#cite_note-68">[68]</a></sup></p>
+<p>President of the Senate <a href="/wiki/Bill_Cole_(West_Virginia_politician)" class="mw-redirect" title="Bill Cole (West Virginia politician)">Bill Cole</a>, college student and former candidate for Mayor of <a href="/wiki/Pineville,_West_Virginia" title="Pineville, West Virginia">Pineville</a> Andrew Utterback, and former <a href="/wiki/Bramwell,_West_Virginia" title="Bramwell, West Virginia">Bramwell</a> Police Chief and former Democratic candidate for House of Delegates Edwin Vanover are running for the Republican nomination. U.S. Representatives <a href="/wiki/David_McKinley" title="David McKinley">David McKinley</a> and <a href="/wiki/Evan_Jenkins_(politician)" title="Evan Jenkins (politician)">Evan Jenkins</a> declined to run for governor. <a href="/wiki/List_of_West_Virginia_Attorneys_General" class="mw-redirect" title="List of West Virginia Attorneys General">West Virginia Attorney General</a> <a href="/wiki/Patrick_Morrisey" title="Patrick Morrisey">Patrick Morrisey</a> had been considered a potential Republican candidate, but instead chose to run for re-election. Potential Republican candidates are State Delegate <a href="/wiki/Erikka_Storch" class="mw-redirect" title="Erikka Storch">Erikka Storch</a> and Olympic gymnast <a href="/wiki/Mary_Lou_Retton" title="Mary Lou Retton">Mary Lou Retton</a>.<sup id="cite_ref-FTWV_69-0" class="reference"><a href="#cite_note-FTWV-69">[69]</a></sup></p>
+<h2><span class="mw-headline" id="Retiring_Republican_incumbents">Retiring Republican incumbents</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=14" title="Edit section: Retiring Republican incumbents">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<h3><span class="mw-headline" id="Jack_Dalrymple_.28North_Dakota.29">Jack Dalrymple (North Dakota)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=15" title="Edit section: Jack Dalrymple (North Dakota)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/North_Dakota_gubernatorial_election,_2016" title="North Dakota gubernatorial election, 2016">North Dakota gubernatorial election, 2016</a></div>
+<p>One-term incumbent <a href="/wiki/Governor_of_North_Dakota" title="Governor of North Dakota">Governor</a> <a href="/wiki/Jack_Dalrymple" title="Jack Dalrymple">Jack Dalrymple</a> declined to seek re-election.<sup id="cite_ref-70" class="reference"><a href="#cite_note-70">[70]</a></sup> Dalrymple was elected to his first full term with 63.1% of the vote in <a href="/wiki/North_Dakota_gubernatorial_election,_2012" title="North Dakota gubernatorial election, 2012">2012</a>, after first taking the seat in 2010 after <a href="/wiki/John_Hoeven" title="John Hoeven">John Hoeven</a> resigned to become a U.S. Senator. Dalrymple was previously <a href="/wiki/Lieutenant_Governor_of_North_Dakota" title="Lieutenant Governor of North Dakota">Lieutenant Governor of North Dakota</a> from 2000 to 2010.</p>
+<p>Republican candidates include Attorney General <a href="/wiki/Wayne_Stenehjem" title="Wayne Stenehjem">Wayne Stenehjem</a>,<sup id="cite_ref-Governing_Predictions_71-0" class="reference"><a href="#cite_note-Governing_Predictions-71">[71]</a></sup> businessman <a href="/wiki/Doug_Burgum" title="Doug Burgum">Doug Burgum</a>,<sup id="cite_ref-72" class="reference"><a href="#cite_note-72">[72]</a></sup> and State Representative and plastic surgeon <a href="/wiki/Rick_Becker" title="Rick Becker">Rick Becker</a>.</p>
+<p>Potential Democratic candidates include former Congressman <a href="/wiki/Earl_Pomeroy" title="Earl Pomeroy">Earl Pomeroy</a>, state Senator <a href="/wiki/George_B._Sinner" title="George B. Sinner">George B. Sinner</a> and state Senate Minority Leader <a href="/wiki/Mac_Schneider" title="Mac Schneider">Mac Schneider</a>.<sup id="cite_ref-Governing_Predictions_71-1" class="reference"><a href="#cite_note-Governing_Predictions-71">[71]</a></sup> Former Agriculture Commissioner <a href="/wiki/Sarah_Vogel" title="Sarah Vogel">Sarah Vogel</a> formed an exploratory a campaign but announced on Jan. 28, 2016 that she will not run for governor. Senator <a href="/wiki/Heidi_Heitkamp" title="Heidi Heitkamp">Heidi Heitkamp</a> declined to run for governor.<sup id="cite_ref-73" class="reference"><a href="#cite_note-73">[73]</a></sup></p>
+<h3><span class="mw-headline" id="Mike_Pence_.28Indiana.29">Mike Pence (Indiana)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=16" title="Edit section: Mike Pence (Indiana)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/Indiana_gubernatorial_election,_2016" title="Indiana gubernatorial election, 2016">Indiana gubernatorial election, 2016</a></div>
+<p>One-term incumbent <a href="/wiki/Governor_of_Indiana" title="Governor of Indiana">Governor</a> <a href="/wiki/Mike_Pence" title="Mike Pence">Mike Pence</a> announced his bid for re-election. Pence won in <a href="/wiki/Indiana_gubernatorial_election,_2012" title="Indiana gubernatorial election, 2012">2012</a> with 49.6% of the vote. Pence previously served as a U.S. Representative from 2001 to 2013 and was Chairman of the <a href="/wiki/House_Republican_Conference" class="mw-redirect" title="House Republican Conference">House Republican Conference</a> from 2009 to 2011. Pence had <a href="/wiki/Republican_Party_presidential_candidates,_2016#Publicly_expressed_interest" title="Republican Party presidential candidates, 2016">expressed interest</a> in running for <a href="/wiki/President_of_the_United_States" title="President of the United States">President of the United States</a> in the <a href="/wiki/United_States_presidential_election,_2016" title="United States presidential election, 2016">2016 presidential election</a>, but declined. However, Pence withdrew his bid for a second term on July 15, 2016, to run for Vice President as running mate to <a href="/wiki/Donald_Trump" title="Donald Trump">Donald Trump</a>.<sup id="cite_ref-74" class="reference"><a href="#cite_note-74">[74]</a></sup><sup id="cite_ref-nbcnews.com_11-1" class="reference"><a href="#cite_note-nbcnews.com-11">[11]</a></sup></p>
+<p>The 2012 Democratic nominee, former State House Speaker <a href="/wiki/John_R._Gregg" title="John R. Gregg">John R. Gregg</a>, is running for the Democratic nomination.<sup id="cite_ref-greggannounce_75-0" class="reference"><a href="#cite_note-greggannounce-75">[75]</a></sup> State Representative Karen Tallian and <a href="/wiki/Indiana_Superintendent_of_Public_Instruction" title="Indiana Superintendent of Public Instruction">Indiana Superintendent of Public Instruction</a> <a href="/wiki/Glenda_Ritz" title="Glenda Ritz">Glenda Ritz</a> both withdrew their candidacies.<sup id="cite_ref-76" class="reference"><a href="#cite_note-76">[76]</a></sup><sup id="cite_ref-77" class="reference"><a href="#cite_note-77">[77]</a></sup> State Representative <a href="/wiki/Terri_Austin" title="Terri Austin">Terri Austin</a>, <a href="/wiki/South_Bend,_Indiana" title="South Bend, Indiana">South Bend</a> Mayor <a href="/wiki/Peter_Buttigieg" class="mw-redirect" title="Peter Buttigieg">Peter Buttigieg</a>, former <a href="/wiki/Lieutenant_Governor_of_Indiana" title="Lieutenant Governor of Indiana">Lieutenant Governor</a> <a href="/wiki/Kathy_Davis" title="Kathy Davis">Kathy Davis</a>, <a href="/wiki/Kokomo,_Indiana" title="Kokomo, Indiana">Kokomo</a> Mayor Greg Goodnight, <a href="/wiki/Lafayette,_Indiana" title="Lafayette, Indiana">Lafayette</a> Mayor Tony Roswarski, and House Minority Leader <a href="/wiki/Scott_Pelath" title="Scott Pelath">Scott Pelath</a> declined to run for governor. Potential Democratic candidates include former <a href="/wiki/United_States_Attorney" title="United States Attorney">United States Attorney</a> for the <a href="/wiki/United_States_District_Court_for_the_Southern_District_of_Indiana" title="United States District Court for the Southern District of Indiana">Southern District of Indiana</a> and former <a href="/wiki/Secretary_of_State_of_Indiana" title="Secretary of State of Indiana">Secretary of State of Indiana</a> <a href="/wiki/Joe_Hogsett" title="Joe Hogsett">Joe Hogsett</a>, President and CEO of the Biocrossroads Initiative and nominee for the U.S. Senate <a href="/wiki/United_States_Senate_election_in_Indiana,_2000" title="United States Senate election in Indiana, 2000">in 2000</a> David Johnson, <a href="/wiki/Hammond,_Indiana" title="Hammond, Indiana">Hammond</a> Mayor <a href="/wiki/Thomas_McDermott,_Jr." title="Thomas McDermott, Jr.">Thomas McDermott, Jr.</a>, physician, former Commissioner for the Indiana State Department of Health and candidate for <a href="/wiki/Indiana%27s_7th_congressional_district" title="Indiana's 7th congressional district">Indiana's 7th congressional district</a> in <a href="/wiki/United_States_House_of_Representatives_elections_in_Indiana,_2008#District_7" title="United States House of Representatives elections in Indiana, 2008">2008</a>, Woody Myers, former <a href="/wiki/Indiana_Senate" title="Indiana Senate">State Senate</a> Minority Leader and nominee for <a href="/wiki/Lieutenant_Governor_of_Indiana" title="Lieutenant Governor of Indiana">Lieutenant Governor</a> in <a href="/wiki/Indiana_gubernatorial_election,_2012" title="Indiana gubernatorial election, 2012">2012</a> <a href="/wiki/Vi_Simpson" title="Vi Simpson">Vi Simpson</a>, U.S. Representative <a href="/wiki/Pete_Visclosky" title="Pete Visclosky">Pete Visclosky</a> and former <a href="/wiki/Evansville,_Indiana" title="Evansville, Indiana">Evansville</a> Mayor <a href="/wiki/Jonathan_Weinzapfel" title="Jonathan Weinzapfel">Jonathan Weinzapfel</a>.<sup id="cite_ref-INFT_78-0" class="reference"><a href="#cite_note-INFT-78">[78]</a></sup><sup id="cite_ref-greggdrops_79-0" class="reference"><a href="#cite_note-greggdrops-79">[79]</a></sup><sup id="cite_ref-bayhnot_80-0" class="reference"><a href="#cite_note-bayhnot-80">[80]</a></sup><sup id="cite_ref-gauging_81-0" class="reference"><a href="#cite_note-gauging-81">[81]</a></sup><sup id="cite_ref-searching_82-0" class="reference"><a href="#cite_note-searching-82">[82]</a></sup><sup id="cite_ref-83" class="reference"><a href="#cite_note-83">[83]</a></sup> Former Governor and Senator <a href="/wiki/Evan_Bayh" title="Evan Bayh">Evan Bayh</a> had considered running,<sup id="cite_ref-INFT_78-1" class="reference"><a href="#cite_note-INFT-78">[78]</a></sup> but has since announced he is running for the <a href="/wiki/United_States_Senate_election_in_Indiana,_2016" title="United States Senate election in Indiana, 2016">U.S. Senate</a> in 2016.<sup id="cite_ref-84" class="reference"><a href="#cite_note-84">[84]</a></sup></p>
+<h2><span class="mw-headline" id="Democratic_incumbents_running_for_re-election">Democratic incumbents running for re-election</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=17" title="Edit section: Democratic incumbents running for re-election">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<h3><span class="mw-headline" id="Kate_Brown_.28Oregon.29">Kate Brown (Oregon)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=18" title="Edit section: Kate Brown (Oregon)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/Oregon_gubernatorial_special_election,_2016" title="Oregon gubernatorial special election, 2016">Oregon gubernatorial special election, 2016</a></div>
+<p><a href="/wiki/Governor_of_Oregon" title="Governor of Oregon">Governor</a> <a href="/wiki/John_Kitzhaber" title="John Kitzhaber">John Kitzhaber</a>, who won reelection in 2014 with 49.9% of the vote, announced his pending resignation on February 13, 2015, amid controversy surrounding <a href="/wiki/Cylvia_Hayes" title="Cylvia Hayes">his fiancee's</a> consulting contracts and work within his administration.<sup id="cite_ref-85" class="reference"><a href="#cite_note-85">[85]</a></sup> <a href="/wiki/Kate_Brown" title="Kate Brown">Kate Brown</a>, Oregon's Secretary of State, was sworn in as Governor on February 18, 2015 upon Kitzhaber's resignation. In accordance with the <a href="/wiki/Constitution_of_Oregon" title="Constitution of Oregon">Constitution of Oregon</a>, a special election will be held in 2016 for the remainder of the term to which Kitzhaber was elected in <a href="/wiki/Oregon_gubernatorial_election,_2014" title="Oregon gubernatorial election, 2014">2014</a>. Brown is running for election to complete the full term.<sup id="cite_ref-86" class="reference"><a href="#cite_note-86">[86]</a></sup> <a href="/wiki/Allen_Alley" title="Allen Alley">Allen Alley</a>, businessman and 2008 Republican nominee for <a href="/wiki/Oregon_State_Treasurer" title="Oregon State Treasurer">Oregon State Treasurer</a> is running for the Republican nomination, along with four other candidates.<sup id="cite_ref-theriault_87-0" class="reference"><a href="#cite_note-theriault-87">[87]</a></sup> <a href="/wiki/Bud_Pierce" title="Bud Pierce">Bud Pierce</a>, a Salem Oncologist, won the Republican Nomination, and is set to face Governor Brown, the Democratic Nominee, in this year's Gubernatorial Election.</p>
+<h3><span class="mw-headline" id="Steve_Bullock_.28Montana.29">Steve Bullock (Montana)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=19" title="Edit section: Steve Bullock (Montana)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/Montana_gubernatorial_election,_2016" title="Montana gubernatorial election, 2016">Montana gubernatorial election, 2016</a></div>
+<p>One-term incumbent <a href="/wiki/Governor_of_Montana" class="mw-redirect" title="Governor of Montana">Governor</a> <a href="/wiki/Steve_Bullock_(Montana_politician)" title="Steve Bullock (Montana politician)">Steve Bullock</a> is running for re-election. Bullock was elected in <a href="/wiki/Montana_gubernatorial_election,_2012" title="Montana gubernatorial election, 2012">2012</a> with 48.9% of the vote. He previously served as <a href="/wiki/Attorney_General_of_Montana" class="mw-redirect" title="Attorney General of Montana">Attorney General of Montana</a> from 2009 to 2013.</p>
+<p>Former Secretary of State Brad Johnson and businessman Mark Perea are running for the Republican nomination.<sup id="cite_ref-ewhitney_88-0" class="reference"><a href="#cite_note-ewhitney-88">[88]</a></sup> <a href="/wiki/Attorney_General_of_Montana" class="mw-redirect" title="Attorney General of Montana">Montana Attorney General</a> <a href="/wiki/Tim_Fox_(politician)" title="Tim Fox (politician)">Tim Fox</a> had been speculated as a potential candidate, but instead chose to run for re-election.<sup id="cite_ref-89" class="reference"><a href="#cite_note-89">[89]</a></sup></p>
+<h3><span class="mw-headline" id="Jay_Inslee_.28Washington.29">Jay Inslee (Washington)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=20" title="Edit section: Jay Inslee (Washington)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/Washington_gubernatorial_election,_2016" title="Washington gubernatorial election, 2016">Washington gubernatorial election, 2016</a></div>
+<p>One-term incumbent <a href="/wiki/Governor_of_Washington" class="mw-redirect" title="Governor of Washington">Governor</a> <a href="/wiki/Jay_Inslee" title="Jay Inslee">Jay Inslee</a> is running for re-election. Inslee was elected in <a href="/wiki/Washington_gubernatorial_election,_2012" title="Washington gubernatorial election, 2012">2012</a> with 51.54% of the vote against <a href="/wiki/Republican_Party_(United_States)" title="Republican Party (United States)">Republican</a> <a href="/wiki/List_of_Attorneys_General_of_Washington" title="List of Attorneys General of Washington">Attorney General</a> <a href="/wiki/Rob_McKenna" title="Rob McKenna">Rob McKenna</a>. Inslee previously served as a U.S. Representative from 1993 to 1995 and from 1999 to 2012. <a href="/wiki/Seattle" title="Seattle">Seattle</a> Port Commissioner Bill Bryant<sup id="cite_ref-what2014_90-0" class="reference"><a href="#cite_note-what2014-90">[90]</a></sup> is running for the Republican nomination. Potential Republican candidates include U.S. Representatives <a href="/wiki/Jaime_Herrera_Beutler" title="Jaime Herrera Beutler">Jaime Herrera Beutler</a> and <a href="/wiki/Cathy_McMorris_Rodgers" title="Cathy McMorris Rodgers">Cathy McMorris Rodgers</a>, State Senator <a href="/wiki/Michael_Baumgartner" title="Michael Baumgartner">Michael Baumgartner</a>, and former State Representative <a href="/wiki/Cathy_Dahlquist" title="Cathy Dahlquist">Cathy Dahlquist</a>.<sup id="cite_ref-what2014_90-1" class="reference"><a href="#cite_note-what2014-90">[90]</a></sup><sup id="cite_ref-McKenna_91-0" class="reference"><a href="#cite_note-McKenna-91">[91]</a></sup><sup id="cite_ref-92" class="reference"><a href="#cite_note-92">[92]</a></sup></p>
+<h3><span class="mw-headline" id="Lolo_Letalu_Matalasi_Moliga_.28American_Samoa.29">Lolo Letalu Matalasi Moliga (American Samoa)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=21" title="Edit section: Lolo Letalu Matalasi Moliga (American Samoa)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>One-term incumbent <a href="/wiki/Governor_of_American_Samoa" class="mw-redirect" title="Governor of American Samoa">Governor</a> <a href="/wiki/Lolo_Letalu_Matalasi_Moliga" class="mw-redirect" title="Lolo Letalu Matalasi Moliga">Lolo Letalu Matalasi Moliga</a> is eligible to run for re-election.<sup id="cite_ref-realclear_93-0" class="reference"><a href="#cite_note-realclear-93">[93]</a></sup> Moliga was elected in <a href="/wiki/American_Samoa_gubernatorial_election,_2012" title="American Samoa gubernatorial election, 2012">2012</a> with 52.9% of the vote in the second round, after taking 33.5% of the vote in the first round. American Samoa requires a second round of voting if no candidate takes a majority of the vote in the first round.</p>
+<h2><span class="mw-headline" id="Republican_incumbents_running_for_re-election">Republican incumbents running for re-election</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=22" title="Edit section: Republican incumbents running for re-election">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<h3><span class="mw-headline" id="Pat_McCrory_.28North_Carolina.29">Pat McCrory (North Carolina)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=23" title="Edit section: Pat McCrory (North Carolina)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/North_Carolina_gubernatorial_election,_2016" title="North Carolina gubernatorial election, 2016">North Carolina gubernatorial election, 2016</a></div>
+<p>One-term incumbent <a href="/wiki/Governor_of_North_Carolina" title="Governor of North Carolina">Governor</a> <a href="/wiki/Pat_McCrory" title="Pat McCrory">Pat McCrory</a> is running for re-election.<sup id="cite_ref-launches_94-0" class="reference"><a href="#cite_note-launches-94">[94]</a></sup> McCrory was elected in <a href="/wiki/North_Carolina_gubernatorial_election,_2012" title="North Carolina gubernatorial election, 2012">2012</a> with 54.7% of the vote. McCrory previously served as <a href="/wiki/Mayor_of_Charlotte" class="mw-redirect" title="Mayor of Charlotte">Mayor of Charlotte</a> from 1995 to 2009.</p>
+<p>For the Democrats, <a href="/wiki/North_Carolina_Attorney_General" title="North Carolina Attorney General">North Carolina Attorney General</a> <a href="/wiki/Roy_Cooper" title="Roy Cooper">Roy Cooper</a><sup id="cite_ref-95" class="reference"><a href="#cite_note-95">[95]</a></sup> and former State Representative <a href="/wiki/Kenneth_Spaulding" title="Kenneth Spaulding">Kenneth Spaulding</a> are declared candidates.<sup id="cite_ref-Eye_96-0" class="reference"><a href="#cite_note-Eye-96">[96]</a></sup> James Protzman, a former <a href="/wiki/Chapel_Hill,_North_Carolina" title="Chapel Hill, North Carolina">Chapel Hill</a> <a href="/wiki/List_of_town_council_members_of_Chapel_Hill,_North_Carolina" title="List of town council members of Chapel Hill, North Carolina">town council member</a>, had declared his candidacy, but later withdrew from the race.<sup id="cite_ref-Eye_96-1" class="reference"><a href="#cite_note-Eye-96">[96]</a></sup><sup id="cite_ref-97" class="reference"><a href="#cite_note-97">[97]</a></sup> <a href="/wiki/United_States_Secretary_of_Transportation" title="United States Secretary of Transportation">United States Secretary of Transportation</a> <a href="/wiki/Anthony_Foxx" title="Anthony Foxx">Anthony Foxx</a> declined to run for governor.</p>
+<h3><span class="mw-headline" id="Gary_Herbert_.28Utah.29">Gary Herbert (Utah)</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=24" title="Edit section: Gary Herbert (Utah)">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div role="note" class="hatnote">Main article: <a href="/wiki/Utah_gubernatorial_election,_2016" title="Utah gubernatorial election, 2016">Utah gubernatorial election, 2016</a></div>
+<p>Incumbent <a href="/wiki/Governor_of_Utah" class="mw-redirect" title="Governor of Utah">Governor</a> <a href="/wiki/Gary_Herbert" title="Gary Herbert">Gary Herbert</a> is running for re-election.<sup id="cite_ref-herbertsays_98-0" class="reference"><a href="#cite_note-herbertsays-98">[98]</a></sup> He was the <a href="/wiki/Lieutenant_Governor_of_Utah" title="Lieutenant Governor of Utah">Lieutenant Governor of Utah</a> from 2005 to 2009 and became Governor after <a href="/wiki/Jon_Huntsman,_Jr." class="mw-redirect" title="Jon Huntsman, Jr.">Jon Huntsman, Jr.</a> resigned to become <a href="/wiki/United_States_Ambassador_to_China" title="United States Ambassador to China">United States Ambassador to China</a>. He won the seat in a <a href="/wiki/Utah_gubernatorial_special_election,_2010" title="Utah gubernatorial special election, 2010">2010 special election</a> and was elected to his first full term with 68.4% of the vote in <a href="/wiki/Utah_gubernatorial_election,_2012" title="Utah gubernatorial election, 2012">2012</a>.</p>
+<p>Other Republican candidate, businessman Jonathan Johnson is running for governor.<sup id="cite_ref-herbertsays_98-1" class="reference"><a href="#cite_note-herbertsays-98">[98]</a></sup> Former Democratic U.S. Representative <a href="/wiki/Jim_Matheson" title="Jim Matheson">Jim Matheson</a> may run.<sup id="cite_ref-tech_99-0" class="reference"><a href="#cite_note-tech-99">[99]</a></sup></p>
+<h2><span class="mw-headline" id="References">References</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit&amp;section=25" title="Edit section: References">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<div class="reflist columns references-column-width" style="-moz-column-width: 30em; -webkit-column-width: 30em; column-width: 30em; list-style-type: decimal;">
+<ol class="references">
+<li id="cite_note-1"><span class="mw-cite-backlink"><b><a href="#cite_ref-1">^</a></b></span> <span class="reference-text">Parentheses around an incumbent's name indicates that the incumbent is retiring, possibly due to term limits.</span></li>
+<li id="cite_note-Cook_Predictions-2"><span class="mw-cite-backlink"><b><a href="#cite_ref-Cook_Predictions_2-0">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://cookpolitical.com/governor/charts/race-ratings">"2015/2016 GOVERNORS RACE RATINGS"</a>. <i>Cook Political Report</i><span class="reference-accessdate">. Retrieved <span class="nowrap">August 12,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=2015%2F2016+GOVERNORS+RACE+RATINGS&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fcookpolitical.com%2Fgovernor%2Fcharts%2Frace-ratings&amp;rft.jtitle=Cook+Political+Report&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-3"><span class="mw-cite-backlink"><b><a href="#cite_ref-3">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.dailykos.com/election-outlook/2016-race-ratings#gubernatorial">"Election Outlook: 2016 Race Ratings"</a>. <i>Daily Kos</i><span class="reference-accessdate">. Retrieved <span class="nowrap">August 22,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Election+Outlook%3A+2016+Race+Ratings&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.dailykos.com%2Felection-outlook%2F2016-race-ratings%23gubernatorial&amp;rft.jtitle=Daily+Kos&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-4"><span class="mw-cite-backlink"><b><a href="#cite_ref-4">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://rothenberggonzales.com/ratings/governor">"2016 Gubernatorial Ratings (August 5, 2016)"</a>. <i>Gubernatorial Ratings</i>. The Rothenberg Political Report<span class="reference-accessdate">. Retrieved <span class="nowrap">August 8,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=2016+Gubernatorial+Ratings+%28August+5%2C+2016%29&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Frothenberggonzales.com%2Fratings%2Fgovernor&amp;rft.jtitle=Gubernatorial+Ratings&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-Sabato_Predictons-5"><span class="mw-cite-backlink"><b><a href="#cite_ref-Sabato_Predictons_5-0">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.centerforpolitics.org/crystalball/2016-governor/">"2016 Governor"</a>. <i>Sabato's Crystal Ball</i>. UVA Center for Politics<span class="reference-accessdate">. Retrieved <span class="nowrap">September 7,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=2016+Governor&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.centerforpolitics.org%2Fcrystalball%2F2016-governor%2F&amp;rft.jtitle=Sabato%27s+Crystal+Ball&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-FEC-6"><span class="mw-cite-backlink"><b><a href="#cite_ref-FEC_6-0">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.fec.gov/pubrec/fe2016/2016pdates.pdf">"2016 PRESIDENTIAL PRIMARY DATES AND CANDIDATE FILING DEADLINES FOR BALLOT ACCESS"</a> <span style="font-size:85%;">(PDF)</span>. <i>FEC</i><span class="reference-accessdate">. Retrieved <span class="nowrap">26 April</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=2016+PRESIDENTIAL+PRIMARY+DATES+AND+CANDIDATE+FILING+DEADLINES+FOR+BALLOT+ACCESS&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.fec.gov%2Fpubrec%2Ffe2016%2F2016pdates.pdf&amp;rft.jtitle=FEC&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-primarytypes-7"><span class="mw-cite-backlink"><b><a href="#cite_ref-primarytypes_7-0">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.ncsl.org/research/elections-and-campaigns/primary-types.aspx">"STATE PRIMARY ELECTION TYPES"</a>. National Conference of State Legislatures. 24 June 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">19 May</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.btitle=STATE+PRIMARY+ELECTION+TYPES&amp;rft.date=2014-06-24&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.ncsl.org%2Fresearch%2Felections-and-campaigns%2Fprimary-types.aspx&amp;rft.pub=National+Conference+of+State+Legislatures&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-8"><span class="mw-cite-backlink"><b><a href="#cite_ref-8">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.delawareonline.com/story/firststatepolitics/2014/11/06/bonini-governor-2016-delaware-politics/18575637/">"Colin Bonini: 'I'm running for governor<span style="padding-right:0.2em;">'</span>"</a>. <i>News Journal</i>. June 14, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">November 2,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Colin+Bonini%3A+%27I%27m+running+for+governor%27&amp;rft.date=2014-06-14&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.delawareonline.com%2Fstory%2Ffirststatepolitics%2F2014%2F11%2F06%2Fbonini-governor-2016-delaware-politics%2F18575637%2F&amp;rft.jtitle=News+Journal&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-9"><span class="mw-cite-backlink"><b><a href="#cite_ref-9">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://atr.rollcall.com/delawares-john-carney-running-governor/">"Delaware Rep. John Carney Running for Governor"</a>. <i>Roll Call</i>. September 16, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">November 2,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Delaware+Rep.+John+Carney+Running+for+Governor&amp;rft.date=2015-09-16&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fatr.rollcall.com%2Fdelawares-john-carney-running-governor%2F&amp;rft.jtitle=Roll+Call&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-lp.org-10"><span class="mw-cite-backlink">^ <a href="#cite_ref-lp.org_10-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-lp.org_10-1"><sup><i><b>b</b></i></sup></a> <a href="#cite_ref-lp.org_10-2"><sup><i><b>c</b></i></sup></a> <a href="#cite_ref-lp.org_10-3"><sup><i><b>d</b></i></sup></a> <a href="#cite_ref-lp.org_10-4"><sup><i><b>e</b></i></sup></a> <a href="#cite_ref-lp.org_10-5"><sup><i><b>f</b></i></sup></a> <a href="#cite_ref-lp.org_10-6"><sup><i><b>g</b></i></sup></a></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.lp.org/candidates-16">"Libertarian Party Candidates – Libertarian Party"</a>. <i>lp.org</i><span class="reference-accessdate">. Retrieved <span class="nowrap">August 2,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Libertarian+Party+Candidates+%93+Libertarian+Party&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.lp.org%2Fcandidates-16&amp;rft.jtitle=lp.org&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-nbcnews.com-11"><span class="mw-cite-backlink">^ <a href="#cite_ref-nbcnews.com_11-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-nbcnews.com_11-1"><sup><i><b>b</b></i></sup></a></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.nbcnews.com/storyline/2016-conventions/its-official-trump-announces-mike-pence-vp-pick-n610111">"It's Official: Trump Announces Pence as VP Pick"</a>. <i>nbcnews.com</i><span class="reference-accessdate">. Retrieved <span class="nowrap">August 2,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=It%27s+Official%3A+Trump+Announces+Pence+as+VP+Pick&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.nbcnews.com%2Fstoryline%2F2016-conventions%2Fits-official-trump-announces-mike-pence-vp-pick-n610111&amp;rft.jtitle=nbcnews.com&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-12"><span class="mw-cite-backlink"><b><a href="#cite_ref-12">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.indystar.com/story/news/politics/2015/04/30/gregg-set-to-announce-governor-bid-pence-rematch-likely/26626999/">"Pence faces bid by Gregg, potential run by Ritz"</a>. <i>Indianapolis Star</i>. April 30, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">May 19,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Pence+faces+bid+by+Gregg%2C+potential+run+by+Ritz&amp;rft.date=2015-04-30&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.indystar.com%2Fstory%2Fnews%2Fpolitics%2F2015%2F04%2F30%2Fgregg-set-to-announce-governor-bid-pence-rematch-likely%2F26626999%2F&amp;rft.jtitle=Indianapolis+Star&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-13"><span class="mw-cite-backlink"><b><a href="#cite_ref-13">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.cnn.com/2016/07/14/politics/donald-trump-vice-presidential-choice/">"Donald Trump selects Mike Pence as VP"</a><span class="reference-accessdate">. Retrieved <span class="nowrap">July 15,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Donald+Trump+selects+Mike+Pence+as+VP&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.cnn.com%2F2016%2F07%2F14%2Fpolitics%2Fdonald-trump-vice-presidential-choice%2F&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-14"><span class="mw-cite-backlink"><b><a href="#cite_ref-14">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.electrexbell.com/">"Rex Bell – for Governor of Indiana"</a>. <i>electrexbell.com</i><span class="reference-accessdate">. Retrieved <span class="nowrap">August 2,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Rex+Bell+%93+for+Governor+of+Indiana&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.electrexbell.com%2F&amp;rft.jtitle=electrexbell.com&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-15"><span class="mw-cite-backlink"><b><a href="#cite_ref-15">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.navytimes.com/story/military/2015/09/26/navy-seal-eric-greitens-run-missouri-governor/72873806/">"Former Navy SEAL Greitens running for Missouri governor"</a>. <i>Navy Times</i>. September 28, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">November 2,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Former+Navy+SEAL+Greitens+running+for+Missouri+governor&amp;rft.date=2015-09-28&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.navytimes.com%2Fstory%2Fmilitary%2F2015%2F09%2F26%2Fnavy-seal-eric-greitens-run-missouri-governor%2F72873806%2F&amp;rft.jtitle=Navy+Times&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-16"><span class="mw-cite-backlink"><b><a href="#cite_ref-16">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://kcur.org/post/despite-greitens-surge-koster-remains-top-money-raiser-battle-missouri-governor">"Despite Greitens' surge, Koster remains the top money-raiser in battle for Missouri governor"</a>. <i>89.3 FM KCUR</i>. July 6, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">July 15,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Despite+Greitens%27+surge%2C+Koster+remains+the+top+money-raiser+in+battle+for+Missouri+governor&amp;rft.date=2015-07-06&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fkcur.org%2Fpost%2Fdespite-greitens-surge-koster-remains-top-money-raiser-battle-missouri-governor&amp;rft.jtitle=89.3+FM+KCUR&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-17"><span class="mw-cite-backlink"><b><a href="#cite_ref-17">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.bozemandailychronicle.com/news/politics/bullock-s-fundraising-picks-up-for-re-election/article_75760f46-96c9-11e4-93b5-7f31d2d6fbf8.html">"Bullock's fundraising picks up for 2016 re-election"</a>. <i>Bozeman Daily Chronicle</i>. January 7, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">November 2,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Bullock%99s+fundraising+picks+up+for+2016+re-election&amp;rft.date=2015-01-07&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.bozemandailychronicle.com%2Fnews%2Fpolitics%2Fbullock-s-fundraising-picks-up-for-re-election%2Farticle_75760f46-96c9-11e4-93b5-7f31d2d6fbf8.html&amp;rft.jtitle=Bozeman+Daily+Chronicle&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-18"><span class="mw-cite-backlink"><b><a href="#cite_ref-18">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.nbcmontana.com/news/Gianforte-officially-launches-campaign-for-Montana-governor/37530178">"Gianforte officially launches campaign for Montana governor"</a>. <i>NBC Montana</i>. 2016-01-21<span class="reference-accessdate">. Retrieved <span class="nowrap">2016-01-22</span></span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Gianforte+officially+launches+campaign+for+Montana+governor&amp;rft.date=2016-01-21&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.nbcmontana.com%2Fnews%2FGianforte-officially-launches-campaign-for-Montana-governor%2F37530178&amp;rft.jtitle=NBC+Montana&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-19"><span class="mw-cite-backlink"><b><a href="#cite_ref-19">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.teddunlap.net/">"Ted Dunlap for Montana Governor"</a>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.btitle=Ted+Dunlap+for+Montana+Governor&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.teddunlap.net%2F&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-20"><span class="mw-cite-backlink"><b><a href="#cite_ref-20">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.wmur.com/politics/-chris-sununu-is-first-candidate-to-declare-run-for-governor-in-2016/35149132">"Chris Sununu is first candidate to declare run for governor in 2016"</a>. <i>WMUR 9</i>. September 8, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">November 2,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Chris+Sununu+is+first+candidate+to+declare+run+for+governor+in+2016&amp;rft.date=2015-09-08&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.wmur.com%2Fpolitics%2F-chris-sununu-is-first-candidate-to-declare-run-for-governor-in-2016%2F35149132&amp;rft.jtitle=WMUR+9&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-21"><span class="mw-cite-backlink"><b><a href="#cite_ref-21">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.wmur.com/politics/democrat-colin-van-ostern-to-run-for-governor/35716994">"Democrat Colin Van Ostern to run for governor"</a>. <i>WMUR9</i>. October 8, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">October 8,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Democrat+Colin+Van+Ostern+to+run+for+governor&amp;rft.date=2015-10-08&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.wmur.com%2Fpolitics%2Fdemocrat-colin-van-ostern-to-run-for-governor%2F35716994&amp;rft.jtitle=WMUR9&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-22"><span class="mw-cite-backlink"><b><a href="#cite_ref-22">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.yourdailyjournal.com/news/home_top-localnews1/153542207/Cooper:-N.C.-better-than-this">"Cooper: N.C. 'better than this<span style="padding-right:0.2em;">'</span>"</a>. <i>Richmond County Daily Journal</i>. Rockingham, North Carolina. May 16, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">May 18,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Cooper%3A+N.C.+%98better+than+this%99&amp;rft.date=2015-05-16&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.yourdailyjournal.com%2Fnews%2Fhome_top-localnews1%2F153542207%2FCooper%3A-N.C.-better-than-this&amp;rft.jtitle=Richmond+County+Daily+Journal&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-23"><span class="mw-cite-backlink"><b><a href="#cite_ref-23">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.newsobserver.com/news/politics-government/politics-columns-blogs/under-the-dome/article10181039.html">"Gov. Pat McCrory launches 2016 campaign website"</a>. <i>The News &amp; Observer</i>. December 2, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">November 5,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Gov.+Pat+McCrory+launches+2016+campaign+website&amp;rft.date=2014-12-02&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.newsobserver.com%2Fnews%2Fpolitics-government%2Fpolitics-columns-blogs%2Funder-the-dome%2Farticle10181039.html&amp;rft.jtitle=The+News+%26+Observer&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-24"><span class="mw-cite-backlink"><b><a href="#cite_ref-24">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.grandforksherald.com/news/politics/3924505-doug-burgum-announces-bid-north-dakota-governor">"Doug Burgum announces bid for North Dakota governor"</a>. <i>Grand Forks Herald</i>. 2016-01-14<span class="reference-accessdate">. Retrieved <span class="nowrap">2016-01-15</span></span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Doug+Burgum+announces+bid+for+North+Dakota+governor&amp;rft.date=2016-01-14&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.grandforksherald.com%2Fnews%2Fpolitics%2F3924505-doug-burgum-announces-bid-north-dakota-governor&amp;rft.jtitle=Grand+Forks+Herald&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-Inforum-25"><span class="mw-cite-backlink"><b><a href="#cite_ref-Inforum_25-0">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.inforum.com/news/3986527-north-dakota-rep-marvin-nelson-join-race-governor?can_id=8c4c59aaca9cda0e0715706b23178adf&amp;source=email-morning-digest-its-duckworth-vs-kirk-in-illinois&amp;email_referrer=morning-digest-its-duckworth-vs-kirk-in-illinois&amp;email_subject=morning-digest-its-duckworth-vs-kirk-in-illinois&amp;link_id=20">"North Dakota Rep. Marvin Nelson to join race for governor"</a>. <i>Inforum</i>. 2016-03-15<span class="reference-accessdate">. Retrieved <span class="nowrap">2016-03-16</span></span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=North+Dakota+Rep.+Marvin+Nelson+to+join+race+for+governor&amp;rft.date=2016-03-15&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.inforum.com%2Fnews%2F3986527-north-dakota-rep-marvin-nelson-join-race-governor%3Fcan_id%3D8c4c59aaca9cda0e0715706b23178adf%26source%3Demail-morning-digest-its-duckworth-vs-kirk-in-illinois%26email_referrer%3Dmorning-digest-its-duckworth-vs-kirk-in-illinois%26email_subject%3Dmorning-digest-its-duckworth-vs-kirk-in-illinois%26link_id%3D20&amp;rft.jtitle=Inforum&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-26"><span class="mw-cite-backlink"><b><a href="#cite_ref-26">^</a></b></span> <span class="reference-text">Brown took office in 2015 after her predecessor, <a href="/wiki/John_Kitzhaber" title="John Kitzhaber">John Kitzhaber</a>, resigned.</span></li>
+<li id="cite_note-27"><span class="mw-cite-backlink"><b><a href="#cite_ref-27">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.eastoregonian.com/eo/local-news/20150918/governor-brown-to-run-for-re-election">"Governor Brown to Run in 2016"</a>. <i>East Oregonian</i>. September 18, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">November 5,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Governor+Brown+to+Run+in+2016&amp;rft.date=2015-09-18&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.eastoregonian.com%2Feo%2Flocal-news%2F20150918%2Fgovernor-brown-to-run-for-re-election&amp;rft.jtitle=East+Oregonian&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-28"><span class="mw-cite-backlink"><b><a href="#cite_ref-28">^</a></b></span> <span class="reference-text"><cite class="citation web">Friedman, Gordon (September 10, 2015). <a rel="nofollow" class="external text" href="http://www.statesmanjournal.com/story/news/politics/elections/2015/09/10/bud-pierce-announces-republican-governor-bid/71941072/">"Bud Pierce announces Republican governor bid"</a>. <i>statesmanjournal.com</i>. Gannett Company<span class="reference-accessdate">. Retrieved <span class="nowrap">January 2,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Bud+Pierce+announces+Republican+governor+bid&amp;rft.aufirst=Gordon&amp;rft.aulast=Friedman&amp;rft.date=2015-09-10&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.statesmanjournal.com%2Fstory%2Fnews%2Fpolitics%2Felections%2F2015%2F09%2F10%2Fbud-pierce-announces-republican-governor-bid%2F71941072%2F&amp;rft.jtitle=statesmanjournal.com&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-29"><span class="mw-cite-backlink"><b><a href="#cite_ref-29">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="https://www.ksl.com/?nid=148&amp;sid=30475796">"Gov. Herbert to run for re-election in 2016"</a>. <i>KSL</i>. June 26, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">November 5,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Gov.+Herbert+to+run+for+re-election+in+2016&amp;rft.date=2014-06-26&amp;rft.genre=article&amp;rft_id=https%3A%2F%2Fwww.ksl.com%2F%3Fnid%3D148%26sid%3D30475796&amp;rft.jtitle=KSL&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-30"><span class="mw-cite-backlink"><b><a href="#cite_ref-30">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.sltrib.com/home/3811556-155/democratic-candidate-for-governor-mike-weinholtz">"Weinholtz wins Dem nomination in Utah governor's race, says wife under investigation for pot possession"</a>. <i>The Salt Lake Tribune</i>. 2016-04-23<span class="reference-accessdate">. Retrieved <span class="nowrap">2016-06-29</span></span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Weinholtz+wins+Dem+nomination+in+Utah+governor%99s+race%2C+says+wife+under+investigation+for+pot+possession&amp;rft.date=2016-04-23&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.sltrib.com%2Fhome%2F3811556-155%2Fdemocratic-candidate-for-governor-mike-weinholtz&amp;rft.jtitle=The+Salt+Lake+Tribune&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-31"><span class="mw-cite-backlink"><b><a href="#cite_ref-31">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.sevendaysvt.com/OffMessage/archives/2015/09/10/sue-minter-to-run-for-vermont-governor">"Sue Minter to Run for Vermont Governor"</a>. <i>Seven Days</i>. September 10, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">November 5,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Sue+Minter+to+Run+for+Vermont+Governor&amp;rft.date=2015-09-10&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.sevendaysvt.com%2FOffMessage%2Farchives%2F2015%2F09%2F10%2Fsue-minter-to-run-for-vermont-governor&amp;rft.jtitle=Seven+Days&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-32"><span class="mw-cite-backlink"><b><a href="#cite_ref-32">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.wptz.com/news/phil-scott-enters-2016-race-for-vt-governor/35143026">"Phil Scott enters 2016 race for Vt. governor"</a>. <i>WPTZ</i>. September 8, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">November 5,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Phil+Scott+enters+2016+race+for+Vt.+governor&amp;rft.date=2015-09-08&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.wptz.com%2Fnews%2Fphil-scott-enters-2016-race-for-vt-governor%2F35143026&amp;rft.jtitle=WPTZ&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-33"><span class="mw-cite-backlink"><b><a href="#cite_ref-33">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.seattletimes.com/seattle-news/politics/port-commissioner-bill-bryant-announces-run-for-governor/">"Port Commissioner Bill Bryant announces run for governor"</a>. <i>Seattle Times</i>. May 14, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">May 15,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Port+Commissioner+Bill+Bryant+announces+run+for+governor&amp;rft.date=2015-05-14&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.seattletimes.com%2Fseattle-news%2Fpolitics%2Fport-commissioner-bill-bryant-announces-run-for-governor%2F&amp;rft.jtitle=Seattle+Times&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-34"><span class="mw-cite-backlink"><b><a href="#cite_ref-34">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://blog.seattlepi.com/seattlepolitics/2015/08/12/gov-inslee-stages-pricey-reelection-fundraiser-in-the-wake-of-a-bad-news-poll/">"Gov. Inslee stages pricey reelection fundraiser in the wake of a bad news poll"</a>. <i>Seattle PI</i>. August 12, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">November 5,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Gov.+Inslee+stages+pricey+reelection+fundraiser+in+the+wake+of+a+bad+news+poll&amp;rft.date=2015-08-12&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fblog.seattlepi.com%2Fseattlepolitics%2F2015%2F08%2F12%2Fgov-inslee-stages-pricey-reelection-fundraiser-in-the-wake-of-a-bad-news-poll%2F&amp;rft.jtitle=Seattle+PI&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-35"><span class="mw-cite-backlink"><b><a href="#cite_ref-35">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://wvpublic.org/post/senate-president-bill-cole-run-governor">"Senate President Bill Cole to Run for Governor"</a>. <i>WV Public Broadcasting</i>. June 2, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">November 5,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Senate+President+Bill+Cole+to+Run+for+Governor&amp;rft.date=2015-06-02&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwvpublic.org%2Fpost%2Fsenate-president-bill-cole-run-governor&amp;rft.jtitle=WV+Public+Broadcasting&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-36"><span class="mw-cite-backlink"><b><a href="#cite_ref-36">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.wsj.com/articles/jim-justice-west-virginia-billionaire-launches-campaign-for-governor-1431380406?alg=y">"Jim Justice, West Virginia Billionaire, Launches Campaign for Governor"</a>. <i><a href="/wiki/Wall_Street_Journal" class="mw-redirect" title="Wall Street Journal">Wall Street Journal</a></i>. May 12, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">November 5,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Jim+Justice%2C+West+Virginia+Billionaire%2C+Launches+Campaign+for+Governor&amp;rft.date=2015-05-12&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.wsj.com%2Farticles%2Fjim-justice-west-virginia-billionaire-launches-campaign-for-governor-1431380406%3Falg%3Dy&amp;rft.jtitle=Wall+Street+Journal&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-37"><span class="mw-cite-backlink"><b><a href="#cite_ref-37">^</a></b></span> <span class="reference-text"><a rel="nofollow" class="external free" href="https://ballotpedia.org/West_Virginia_gubernatorial_election,_2016">https://ballotpedia.org/West_Virginia_gubernatorial_election,_2016</a></span></li>
+<li id="cite_note-ncsl2-38"><span class="mw-cite-backlink"><b><a href="#cite_ref-ncsl2_38-0">^</a></b></span> <span class="reference-text"><cite class="citation news">Warnock, Kae (11 March 2016). <a rel="nofollow" class="external text" href="http://www.ncsl.org/research/elections-and-campaigns/2016-legislative-races-by-state-and-legislative-chamber.aspx">"2016 LEGISLATIVE RACES BY STATE AND LEGISLATIVE CHAMBER"</a>. National Conference of State Legislatures<span class="reference-accessdate">. Retrieved <span class="nowrap">17 May</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=2016+LEGISLATIVE+RACES+BY+STATE+AND+LEGISLATIVE+CHAMBER&amp;rft.aufirst=Kae&amp;rft.aulast=Warnock&amp;rft.date=2016-03-11&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.ncsl.org%2Fresearch%2Felections-and-campaigns%2F2016-legislative-races-by-state-and-legislative-chamber.aspx&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-ncsl-39"><span class="mw-cite-backlink"><b><a href="#cite_ref-ncsl_39-0">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.ncsl.org/Portals/1/Documents/Elections/Legis_Control_2016_Apr20.pdf">"2016 State and Legislative Partisan Composition"</a> <span style="font-size:85%;">(PDF)</span>. <i>National Conference of State Legislatures</i><span class="reference-accessdate">. Retrieved <span class="nowrap">17 May</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=2016+State+and+Legislative+Partisan+Composition&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.ncsl.org%2FPortals%2F1%2FDocuments%2FElections%2FLegis_Control_2016_Apr20.pdf&amp;rft.jtitle=National+Conference+of+State+Legislatures&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-40"><span class="mw-cite-backlink"><b><a href="#cite_ref-40">^</a></b></span> <span class="reference-text">DE Const. art. III, §&#160;5</span></li>
+<li id="cite_note-41"><span class="mw-cite-backlink"><b><a href="#cite_ref-41">^</a></b></span> <span class="reference-text"><cite class="citation web">Daniel Harper (May 30, 2015). <a rel="nofollow" class="external text" href="http://www.weeklystandard.com/blogs/joe-biden-announces-passing-son-beau-biden_960494.html">"Joe Biden Announces Passing of Son, Beau Biden"</a>. <i>The Weekly Standard</i>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Joe+Biden+Announces+Passing+of+Son%2C+Beau+Biden&amp;rft.au=Daniel+Harper&amp;rft.date=2015-05-30&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.weeklystandard.com%2Fblogs%2Fjoe-biden-announces-passing-son-beau-biden_960494.html&amp;rft.jtitle=The+Weekly+Standard&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-42"><span class="mw-cite-backlink"><b><a href="#cite_ref-42">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://politicalticker.blogs.cnn.com/2014/04/17/beau-biden-says-he-plans-to-run-for-governor-in-delaware/?hpt=hp_t2">"Beau Biden says he plans to run for governor in Delaware"</a>. <i>CNN</i>. April 17, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">April 17,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Beau+Biden+says+he+plans+to+run+for+governor+in+Delaware&amp;rft.date=2014-04-17&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fpoliticalticker.blogs.cnn.com%2F2014%2F04%2F17%2Fbeau-biden-says-he-plans-to-run-for-governor-in-delaware%2F%3Fhpt%3Dhp_t2&amp;rft.jtitle=CNN&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-43"><span class="mw-cite-backlink"><b><a href="#cite_ref-43">^</a></b></span> <span class="reference-text"><cite class="citation news">Bruggeman, Karyn; Railey, Kimberly (September 16, 2015). <a rel="nofollow" class="external text" href="http://www.nationaljournal.com/s/73082/rep-john-carney-run-governor-delaware">"Rep. John Carney to Run for Governor of Delaware"</a>. <i><a href="/wiki/National_Journal" title="National Journal">National Journal</a></i><span class="reference-accessdate">. Retrieved <span class="nowrap">September 16,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Rep.+John+Carney+to+Run+for+Governor+of+Delaware&amp;rft.aufirst=Karyn&amp;rft.aulast=Bruggeman&amp;rft.au=Railey%2C+Kimberly&amp;rft.date=2015-09-16&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.nationaljournal.com%2Fs%2F73082%2Frep-john-carney-run-governor-delaware&amp;rft.jtitle=National+Journal&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-Biden-44"><span class="mw-cite-backlink"><b><a href="#cite_ref-Biden_44-0">^</a></b></span> <span class="reference-text"><cite class="citation news">McPike, Erin (September 11, 2012). <a rel="nofollow" class="external text" href="http://www.realclearpolitics.com/2012/11/09/is_beau_biden_democrats039_next_emerging_star_295630.html">"Is Beau Biden Democrats' Next Emerging Star?"</a>. <i>RealClearPolitics</i><span class="reference-accessdate">. Retrieved <span class="nowrap">March 3,</span> 2013</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Is+Beau+Biden+Democrats%27+Next+Emerging+Star%3F&amp;rft.aufirst=Erin&amp;rft.aulast=McPike&amp;rft.date=2012-09-11&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.realclearpolitics.com%2F2012%2F11%2F09%2Fis_beau_biden_democrats039_next_emerging_star_295630.html&amp;rft.jtitle=RealClearPolitics&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-Nixon_term_limits-45"><span class="mw-cite-backlink"><b><a href="#cite_ref-Nixon_term_limits_45-0">^</a></b></span> <span class="reference-text"><cite class="citation news">McClellan, Bill (May 10, 2012). <a rel="nofollow" class="external text" href="http://www.stltoday.com/news/local/columns/bill-mcclellan/bill-mcclellan-jay-nixon-could-make-presidential-bid-in/article_21c02e01-1968-5a2e-8758-f6d0f2405cb3.html">"Bill McClellan: Jay Nixon could make presidential bid in 2016"</a>. <i>St. Louis Post Dispatch</i><span class="reference-accessdate">. Retrieved <span class="nowrap">March 3,</span> 2013</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Bill+McClellan%3A+Jay+Nixon+could+make+presidential+bid+in+2016&amp;rft.aufirst=Bill&amp;rft.aulast=McClellan&amp;rft.date=2012-05-10&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.stltoday.com%2Fnews%2Flocal%2Fcolumns%2Fbill-mcclellan%2Fbill-mcclellan-jay-nixon-could-make-presidential-bid-in%2Farticle_21c02e01-1968-5a2e-8758-f6d0f2405cb3.html&amp;rft.jtitle=St.+Louis+Post+Dispatch&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-46"><span class="mw-cite-backlink"><b><a href="#cite_ref-46">^</a></b></span> <span class="reference-text"><cite class="citation news">AP (July 16, 2015). <a rel="nofollow" class="external text" href="http://www.kshb.com/news/state/missouri/missouri-attorney-general-chris-koster-has-nearly-4-million-for-missouri-governor-campaign">"Missouri Attorney General Chris Koster has nearly $4 million for governor campaign"</a>. KSHB Kansas City<span class="reference-accessdate">. Retrieved <span class="nowrap">September 15,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Missouri+Attorney+General+Chris+Koster+has+nearly+%244+million+for+governor+campaign&amp;rft.au=AP&amp;rft.date=2015-07-16&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.kshb.com%2Fnews%2Fstate%2Fmissouri%2Fmissouri-attorney-general-chris-koster-has-nearly-4-million-for-missouri-governor-campaign&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-47"><span class="mw-cite-backlink"><b><a href="#cite_ref-47">^</a></b></span> <span class="reference-text"><cite class="citation web">Yokley, Eli (January 12, 2015). <a rel="nofollow" class="external text" href="http://politicmo.com/2015/01/12/claire-mccaskill-governor-koster/">"Claire McCaskill will not run for governor in 2016"</a>. <i>PoliticMo</i><span class="reference-accessdate">. Retrieved <span class="nowrap">January 12,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Claire+McCaskill+will+not+run+for+governor+in+2016&amp;rft.aufirst=Eli&amp;rft.aulast=Yokley&amp;rft.date=2015-01-12&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fpoliticmo.com%2F2015%2F01%2F12%2Fclaire-mccaskill-governor-koster%2F&amp;rft.jtitle=PoliticMo&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-48"><span class="mw-cite-backlink"><b><a href="#cite_ref-48">^</a></b></span> <span class="reference-text"><cite class="citation news">Rosenbaum, Jason (April 9, 2013). <a rel="nofollow" class="external text" href="https://www.stlbeacon.org/#!/content/30266/zweifel_governor_koster_departure">"Zweifel decides against 2016 bid for governor"</a>. <i>St. Louis Beacon</i><span class="reference-accessdate">. Retrieved <span class="nowrap">April 10,</span> 2013</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Zweifel+decides+against+2016+bid+for+governor&amp;rft.aufirst=Jason&amp;rft.aulast=Rosenbaum&amp;rft.date=2013-04-09&amp;rft.genre=article&amp;rft_id=https%3A%2F%2Fwww.stlbeacon.org%2F%23%21%2Fcontent%2F30266%2Fzweifel_governor_koster_departure&amp;rft.jtitle=St.+Louis+Beacon&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-auto-49"><span class="mw-cite-backlink">^ <a href="#cite_ref-auto_49-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-auto_49-1"><sup><i><b>b</b></i></sup></a></span> <span class="reference-text"><cite class="citation web">Martellaro, Alexandria. <a rel="nofollow" class="external text" href="http://www.ksdk.com/news/politics/koster-greitens-win-party-nominations-for-governor/286681986">"Greitens, Koster win gubernatorial primaries"</a>. <i>KSDK</i>. KSDK News<span class="reference-accessdate">. Retrieved <span class="nowrap">17 August</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Greitens%2C+Koster+win+gubernatorial+primaries&amp;rft.aufirst=Alexandria&amp;rft.aulast=Martellaro&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.ksdk.com%2Fnews%2Fpolitics%2Fkoster-greitens-win-party-nominations-for-governor%2F286681986&amp;rft.jtitle=KSDK&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-50"><span class="mw-cite-backlink"><b><a href="#cite_ref-50">^</a></b></span> <span class="reference-text"><cite class="citation news">Scher Zagier, Alan; Ballentine, Summer (September 26, 2015). <a rel="nofollow" class="external text" href="http://www.kansascity.com/news/government-politics/article36693603.html">"Former Navy SEAL Greitens running as Republican for Missouri governor"</a>. <i><a href="/wiki/The_Kansas_City_Star" title="The Kansas City Star">The Kansas City Star</a></i><span class="reference-accessdate">. Retrieved <span class="nowrap">September 28,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Former+Navy+SEAL+Greitens+running+as+Republican+for+Missouri+governor&amp;rft.au=Ballentine%2C+Summer&amp;rft.aufirst=Alan&amp;rft.aulast=Scher+Zagier&amp;rft.date=2015-09-26&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.kansascity.com%2Fnews%2Fgovernment-politics%2Farticle36693603.html&amp;rft.jtitle=The+Kansas+City+Star&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-51"><span class="mw-cite-backlink"><b><a href="#cite_ref-51">^</a></b></span> <span class="reference-text"><cite class="citation news">Giacomo Bologna (October 2, 2013). <a rel="nofollow" class="external text" href="http://www.rollcall.com/news/show_me_nothing_missouri_members_entrenched-228101-1.html">"Show Me Nothing: Missouri Members Entrenched"</a>. <i>Roll Call</i><span class="reference-accessdate">. Retrieved <span class="nowrap">October 3,</span> 2013</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Show+Me+Nothing%3A+Missouri+Members+Entrenched&amp;rft.au=Giacomo+Bologna&amp;rft.date=2013-10-02&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.rollcall.com%2Fnews%2Fshow_me_nothing_missouri_members_entrenched-228101-1.html&amp;rft.jtitle=Roll+Call&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-52"><span class="mw-cite-backlink"><b><a href="#cite_ref-52">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://moscout.com/greitens-for-gov/">"Greitens for Gov?"</a>. Missouri Scout. July 8, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">November 25,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.btitle=Greitens+for+Gov%3F&amp;rft.date=2014-07-08&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fmoscout.com%2Fgreitens-for-gov%2F&amp;rft.pub=Missouri+Scout&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-53"><span class="mw-cite-backlink"><b><a href="#cite_ref-53">^</a></b></span> <span class="reference-text"><cite class="citation news">Wingo, Kelsey (January 13, 2015). <a rel="nofollow" class="external text" href="http://themissouritimes.com/15842/bart-korman-running-governor/">"Is Bart Korman running for governor?"</a>. <i>The Missouri Times</i><span class="reference-accessdate">. Retrieved <span class="nowrap">January 28,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Is+Bart+Korman+running+for+governor%3F&amp;rft.aufirst=Kelsey&amp;rft.aulast=Wingo&amp;rft.date=2015-01-13&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fthemissouritimes.com%2F15842%2Fbart-korman-running-governor%2F&amp;rft.jtitle=The+Missouri+Times&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-54"><span class="mw-cite-backlink"><b><a href="#cite_ref-54">^</a></b></span> <span class="reference-text"><cite class="citation web">Joe Millitzer (February 26, 2015). <a rel="nofollow" class="external text" href="http://fox2now.com/2015/02/26/missouri-auditor-schweich-hospitalized-for-medical-problem/">"Missouri Auditor Schweich dies after self-inflicted gunshot wound"</a>. <a href="/wiki/KTVI" title="KTVI">KTVI</a> Fox 2 Now.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.au=Joe+Millitzer&amp;rft.btitle=Missouri+Auditor+Schweich+dies+after+self-inflicted+gunshot+wound&amp;rft.date=2015-02-26&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Ffox2now.com%2F2015%2F02%2F26%2Fmissouri-auditor-schweich-hospitalized-for-medical-problem%2F&amp;rft.pub=KTVI+Fox+2+Now&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-16in16-55"><span class="mw-cite-backlink"><b><a href="#cite_ref-16in16_55-0">^</a></b></span> <span class="reference-text"><cite class="citation web">Cheney, Kyle (December 29, 2014). <a rel="nofollow" class="external text" href="http://www.politico.com/story/2014/12/2016-senate-races-113837_Page4.html">"16 in '16: The new battle for the Senate"</a>. <i><a href="/wiki/Politico" title="Politico">Politico</a></i><span class="reference-accessdate">. Retrieved <span class="nowrap">December 29,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=16+in+%2716%3A+The+new+battle+for+the+Senate&amp;rft.aufirst=Kyle&amp;rft.aulast=Cheney&amp;rft.date=2014-12-29&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.politico.com%2Fstory%2F2014%2F12%2F2016-senate-races-113837_Page4.html&amp;rft.jtitle=Politico&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-56"><span class="mw-cite-backlink"><b><a href="#cite_ref-56">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.nh1.com/news/chris-sununu-announces-run-for-nh-governor/">"Chris Sununu announces run for NH Governor"</a>. NH1.com. January 14, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">September 7,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.btitle=Chris+Sununu+announces+run+for+NH+Governor&amp;rft.date=2015-01-14&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.nh1.com%2Fnews%2Fchris-sununu-announces-run-for-nh-governor%2F&amp;rft.pub=NH1.com&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-57"><span class="mw-cite-backlink"><b><a href="#cite_ref-57">^</a></b></span> <span class="reference-text"><cite class="citation web">Adam Sexton (January 14, 2015). <a rel="nofollow" class="external text" href="http://www.wmur.com/politics/lozeau-says-shes-not-running-for-nashua-mayor-again/30704858">"Lozeau says she's not running for Nashua mayor again"</a>. WMUR9<span class="reference-accessdate">. Retrieved <span class="nowrap">January 16,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.au=Adam+Sexton&amp;rft.btitle=Lozeau+says+she%27s+not+running+for+Nashua+mayor+again&amp;rft.date=2015-01-14&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.wmur.com%2Fpolitics%2Flozeau-says-shes-not-running-for-nashua-mayor-again%2F30704858&amp;rft.pub=WMUR9&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-58"><span class="mw-cite-backlink"><b><a href="#cite_ref-58">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://news.yahoo.com/puerto-rico-governor-not-seek-reelection-232840409.html">"Puerto Rico governor will not seek reelection"</a>. Yahoo. December 15, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">December 15,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.btitle=Puerto+Rico+governor+will+not+seek+reelection&amp;rft.date=2015-12-15&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fnews.yahoo.com%2Fpuerto-rico-governor-not-seek-reelection-232840409.html&amp;rft.pub=Yahoo&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-59"><span class="mw-cite-backlink"><b><a href="#cite_ref-59">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.caribbeanbusinesspr.com/news03.php?nt_id=75736&amp;ct_id=1">"Fortuño: Romney would be good for PR"</a>. <i><a href="/wiki/Caribbean_Business" class="mw-redirect" title="Caribbean Business">Caribbean Business</a></i>. August 28, 2012<span class="reference-accessdate">. Retrieved <span class="nowrap">January 15,</span> 2013</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Fortu%C3%B1o%3A+Romney+would+be+good+for+PR&amp;rft.date=2012-08-28&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.caribbeanbusinesspr.com%2Fnews03.php%3Fnt_id%3D75736%26ct_id%3D1&amp;rft.jtitle=Caribbean+Business&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-60"><span class="mw-cite-backlink"><b><a href="#cite_ref-60">^</a></b></span> <span class="reference-text"><cite class="citation web">Brown, Nick (December 16, 2015). <a rel="nofollow" class="external text" href="http://in.reuters.com/article/usa-puertorico-election-idINKBN0TY2JO20151216">"Bernier plans to announce Puerto Rico governor bid Wednesday"</a>. Reuters<span class="reference-accessdate">. Retrieved <span class="nowrap">December 16,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.au=Brown%2C+Nick&amp;rft.btitle=Bernier+plans+to+announce+Puerto+Rico+governor+bid+Wednesday&amp;rft.date=2015-12-16&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fin.reuters.com%2Farticle%2Fusa-puertorico-election-idINKBN0TY2JO20151216&amp;rft.pub=Reuters&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-PierlusiGov-61"><span class="mw-cite-backlink"><b><a href="#cite_ref-PierlusiGov_61-0">^</a></b></span> <span class="reference-text"><cite class="citation news">Gonzalez, Rocio (November 12, 2012). <a rel="nofollow" class="external text" href="http://www.voxxi.com/puerto-rico-pedro-pierluisi-four-years/">"Unlike Puerto Rico governor, Pedro Pierluisi has four more years"</a>. <i>Voxx</i><span class="reference-accessdate">. Retrieved <span class="nowrap">March 4,</span> 2013</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Unlike+Puerto+Rico+governor%2C+Pedro+Pierluisi+has+four+more+years&amp;rft.aufirst=Rocio&amp;rft.aulast=Gonzalez&amp;rft.date=2012-11-12&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.voxxi.com%2Fpuerto-rico-pedro-pierluisi-four-years%2F&amp;rft.jtitle=Voxx&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-62"><span class="mw-cite-backlink"><b><a href="#cite_ref-62">^</a></b></span> <span class="reference-text"><cite class="citation news">Ben Kamisar (June 8, 2015). <a rel="nofollow" class="external text" href="http://thehill.com/blogs/ballot-box/governor-races/244301-vermont-governor-will-not-seek-reelection">"Vermont governor will not seek reelection"</a>. <i>The Hill</i><span class="reference-accessdate">. Retrieved <span class="nowrap">June 8,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Vermont+governor+will+not+seek+reelection&amp;rft.au=Ben+Kamisar&amp;rft.date=2015-06-08&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fthehill.com%2Fblogs%2Fballot-box%2Fgovernor-races%2F244301-vermont-governor-will-not-seek-reelection&amp;rft.jtitle=The+Hill&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-shumlinbeatsmilne-63"><span class="mw-cite-backlink"><b><a href="#cite_ref-shumlinbeatsmilne_63-0">^</a></b></span> <span class="reference-text"><cite class="citation news">Free Press Staff (January 8, 2015). <a rel="nofollow" class="external text" href="http://www.burlingtonfreepress.com/story/news/politics/2015/01/08/vermont-legislature-vote/21394309/">"Shumlin defeats Milne in Legislature governor vote"</a><span class="reference-accessdate">. Retrieved <span class="nowrap">January 8,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Shumlin+defeats+Milne+in+Legislature+governor+vote&amp;rft.au=Free+Press+Staff&amp;rft.date=2015-01-08&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.burlingtonfreepress.com%2Fstory%2Fnews%2Fpolitics%2F2015%2F01%2F08%2Fvermont-legislature-vote%2F21394309%2F&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-thallenbeck-64"><span class="mw-cite-backlink">^ <a href="#cite_ref-thallenbeck_64-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-thallenbeck_64-1"><sup><i><b>b</b></i></sup></a></span> <span class="reference-text"><cite class="citation web">Hallenbeck, Terri (September 8, 2015). <a rel="nofollow" class="external text" href="http://www.sevendaysvt.com/OffMessage/archives/2015/09/08/scott-pins-gubernatorial-campaign-on-fiscal-responsibility">"Scott Pins Gubernatorial Campaign on 'Fiscal Responsibility<span style="padding-right:0.2em;">'</span>"</a>. <i>sevendaysvt.com</i><span class="reference-accessdate">. Retrieved <span class="nowrap">September 8,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Scott+Pins+Gubernatorial+Campaign+on+%27Fiscal+Responsibility%27&amp;rft.aufirst=Terri&amp;rft.aulast=Hallenbeck&amp;rft.date=2015-09-08&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.sevendaysvt.com%2FOffMessage%2Farchives%2F2015%2F09%2F08%2Fscott-pins-gubernatorial-campaign-on-fiscal-responsibility&amp;rft.jtitle=sevendaysvt.com&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-Circus-65"><span class="mw-cite-backlink">^ <a href="#cite_ref-Circus_65-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-Circus_65-1"><sup><i><b>b</b></i></sup></a></span> <span class="reference-text">April Burbank, Paris Achen &amp; Mike Donoghue, <a rel="nofollow" class="external text" href="http://www.burlingtonfreepress.com/story/news/2015/06/08/shumlin-decided-against-2016-re-election/28690591/">Shumlin's decision kicks off political 'circus'</a>, <i>Burlington Free Press</i> (June 8, 2015).</span></li>
+<li id="cite_note-Galloway-66"><span class="mw-cite-backlink">^ <a href="#cite_ref-Galloway_66-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-Galloway_66-1"><sup><i><b>b</b></i></sup></a></span> <span class="reference-text">Anne Galloway, <a rel="nofollow" class="external text" href="http://vtdigger.org/2015/06/08/crowded-field-likely-to-line-up-for-open-governors-seat/">Crowded field likely to line up for open governor's seat</a>, Vtdigger (June 8, 2015).</span></li>
+<li id="cite_note-TomblinTermLimits-67"><span class="mw-cite-backlink"><b><a href="#cite_ref-TomblinTermLimits_67-0">^</a></b></span> <span class="reference-text"><cite class="citation news">King, Joselyn (May 18, 2011). <a rel="nofollow" class="external text" href="http://wetzelchronicle.com/page/content.detail/id/504690/Tomblin--Maloney-Win-Nominations.html?nav=5001">"Tomblin, Maloney win nominations"</a>. <i>Wetzel Chronicle</i><span class="reference-accessdate">. Retrieved <span class="nowrap">March 3,</span> 2013</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Tomblin%2C+Maloney+win+nominations&amp;rft.aufirst=Joselyn&amp;rft.aulast=King&amp;rft.date=2011-05-18&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwetzelchronicle.com%2Fpage%2Fcontent.detail%2Fid%2F504690%2FTomblin--Maloney-Win-Nominations.html%3Fnav%3D5001&amp;rft.jtitle=Wetzel+Chronicle&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-68"><span class="mw-cite-backlink"><b><a href="#cite_ref-68">^</a></b></span> <span class="reference-text"><cite class="citation news">Raby, John (May 10, 2015). <a rel="nofollow" class="external text" href="http://www.herald-dispatch.com/elections/jim-justice-wins-democratic-nomination-for-west-virginia-gov/article_4feb8f22-9ea2-5ed3-bf31-4b887b799b8c.html">"Jim Justice wins Democratic nomination for West Virginia gov"</a>. <i><a href="/wiki/The_Herald-Dispatch" title="The Herald-Dispatch">The Herald-Dispatch</a></i><span class="reference-accessdate">. Retrieved <span class="nowrap">October 5,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Jim+Justice+wins+Democratic+nomination+for+West+Virginia+gov&amp;rft.aufirst=John&amp;rft.aulast=Raby&amp;rft.date=2015-05-10&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.herald-dispatch.com%2Felections%2Fjim-justice-wins-democratic-nomination-for-west-virginia-gov%2Farticle_4feb8f22-9ea2-5ed3-bf31-4b887b799b8c.html&amp;rft.jtitle=The+Herald-Dispatch&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-FTWV-69"><span class="mw-cite-backlink"><b><a href="#cite_ref-FTWV_69-0">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.rollcall.com/news/west_virginia_undergoing_political_generational_change-232603-1.html?pos=hln">"West Virginia Undergoing Political, Generational Change"</a>. <i>Roll Call</i>. May 1, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">May 1,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=West+Virginia+Undergoing+Political%2C+Generational+Change&amp;rft.date=2014-05-01&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.rollcall.com%2Fnews%2Fwest_virginia_undergoing_political_generational_change-232603-1.html%3Fpos%3Dhln&amp;rft.jtitle=Roll+Call&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-70"><span class="mw-cite-backlink"><b><a href="#cite_ref-70">^</a></b></span> <span class="reference-text"><cite class="citation news">Scheyder, Ernest. <a rel="nofollow" class="external text" href="http://www.reuters.com/article/2015/08/24/us-north-dakota-governor-idUSKCN0QT20B20150824">"North Dakota's governor says will not seek re-election in 2016"</a>. <i>Reuters</i><span class="reference-accessdate">. Retrieved <span class="nowrap">August 24,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=North+Dakota%27s+governor+says+will+not+seek+re-election+in+2016&amp;rft.aufirst=Ernest&amp;rft.aulast=Scheyder&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.reuters.com%2Farticle%2F2015%2F08%2F24%2Fus-north-dakota-governor-idUSKCN0QT20B20150824&amp;rft.jtitle=Reuters&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-Governing_Predictions-71"><span class="mw-cite-backlink">^ <a href="#cite_ref-Governing_Predictions_71-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-Governing_Predictions_71-1"><sup><i><b>b</b></i></sup></a></span> <span class="reference-text"><cite class="citation news">Jacobson, Louis (January 23, 2015). <a rel="nofollow" class="external text" href="http://www.governing.com/topics/politics/gov-democrats-seats-defend-2015-2016-governors-races.html">"Democrats Have More Seats to Defend in 2015–2016 Governors Races"</a>. Governing Magazine<span class="reference-accessdate">. Retrieved <span class="nowrap">January 27,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Democrats+Have+More+Seats+to+Defend+in+2015%932016+Governors+Races&amp;rft.aufirst=Louis&amp;rft.aulast=Jacobson&amp;rft.date=2015-01-23&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.governing.com%2Ftopics%2Fpolitics%2Fgov-democrats-seats-defend-2015-2016-governors-races.html&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span> Governing Magazine uses a scale of "vulnerable", "potentially vulnerable", and "safe."</span></li>
+<li id="cite_note-72"><span class="mw-cite-backlink"><b><a href="#cite_ref-72">^</a></b></span> <span class="reference-text"><cite class="citation news">Springer, Patrick. <a rel="nofollow" class="external text" href="http://www.grandforksherald.com/news/politics/3924505-doug-burgum-announces-bid-north-dakota-governor">"Doug Burgum announces bid for North Dakota governor"</a>. <i>Grand Forks Herald</i><span class="reference-accessdate">. Retrieved <span class="nowrap">May 21,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Doug+Burgum+announces+bid+for+North+Dakota+governor&amp;rft.aufirst=Patrick&amp;rft.aulast=Springer&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.grandforksherald.com%2Fnews%2Fpolitics%2F3924505-doug-burgum-announces-bid-north-dakota-governor&amp;rft.jtitle=Grand+Forks+Herald&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-73"><span class="mw-cite-backlink"><b><a href="#cite_ref-73">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.inforum.com/news/3835235-heitkamp-says-she-wont-run-governor-2016/">"Heitkamp says she won't run for governor in 2016"</a>. In Forum. September 9, 2015<span class="reference-accessdate">. Retrieved <span class="nowrap">September 9,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.btitle=Heitkamp+says+she+won%27t+run+for+governor+in+2016&amp;rft.date=2015-09-09&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.inforum.com%2Fnews%2F3835235-heitkamp-says-she-wont-run-governor-2016%2F&amp;rft.pub=In+Forum&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-74"><span class="mw-cite-backlink"><b><a href="#cite_ref-74">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="https://twitter.com/realDonaldTrump/status/753965070003109888">"Donald J. Trump on Twitter"</a>. <i>twitter.com</i><span class="reference-accessdate">. Retrieved <span class="nowrap">August 2,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Donald+J.+Trump+on+Twitter&amp;rft.genre=unknown&amp;rft_id=https%3A%2F%2Ftwitter.com%2FrealDonaldTrump%2Fstatus%2F753965070003109888&amp;rft.jtitle=twitter.com&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-greggannounce-75"><span class="mw-cite-backlink"><b><a href="#cite_ref-greggannounce_75-0">^</a></b></span> <span class="reference-text"><cite class="citation web">LoBianco, Tom (April 30, 2015). <a rel="nofollow" class="external text" href="http://www.indystar.com/story/news/politics/2015/04/30/gregg-set-to-announce-governor-bid-pence-rematch-likely/26626999/">"Source: Democrat John Gregg set to announce governor bid"</a>. <i><a href="/wiki/The_Indianapolis_Star" title="The Indianapolis Star">The Indianapolis Star</a></i><span class="reference-accessdate">. Retrieved <span class="nowrap">April 30,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Source%3A+Democrat+John+Gregg+set+to+announce+governor+bid&amp;rft.aufirst=Tom&amp;rft.aulast=LoBianco&amp;rft.date=2015-04-30&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.indystar.com%2Fstory%2Fnews%2Fpolitics%2F2015%2F04%2F30%2Fgregg-set-to-announce-governor-bid-pence-rematch-likely%2F26626999%2F&amp;rft.jtitle=The+Indianapolis+Star&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-76"><span class="mw-cite-backlink"><b><a href="#cite_ref-76">^</a></b></span> <span class="reference-text"><cite class="citation web">Cook, Tony; Schneider, Chelsea (August 7, 2015). <a rel="nofollow" class="external text" href="http://www.indystar.com/story/news/politics/2015/08/07/glenda-ritz-drops-out--governors-race/31307459/">"Glenda Ritz drops out of governor's race"</a>. <i><a href="/wiki/The_Indianapolis_Star" title="The Indianapolis Star">The Indianapolis Star</a></i><span class="reference-accessdate">. Retrieved <span class="nowrap">August 7,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Glenda+Ritz+drops+out+of+governor%27s+race&amp;rft.aufirst=Tony&amp;rft.aulast=Cook&amp;rft.au=Schneider%2C+Chelsea&amp;rft.date=2015-08-07&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.indystar.com%2Fstory%2Fnews%2Fpolitics%2F2015%2F08%2F07%2Fglenda-ritz-drops-out--governors-race%2F31307459%2F&amp;rft.jtitle=The+Indianapolis+Star&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-77"><span class="mw-cite-backlink"><b><a href="#cite_ref-77">^</a></b></span> <span class="reference-text"><cite class="citation web">Carden, Dan (August 17, 2015). <a rel="nofollow" class="external text" href="http://www.nwitimes.com/news/local/govt-and-politics/elections/tallian-drops-out-of-governor-s-race/article_73b5ffef-4ce1-536c-9825-568ca5d660a4.html">"Tallian drops out of governor's race"</a>. <i><a href="/wiki/The_Times_of_Northwest_Indiana" title="The Times of Northwest Indiana">The Times of Northwest Indiana</a></i><span class="reference-accessdate">. Retrieved <span class="nowrap">August 17,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Tallian+drops+out+of+governor%27s+race&amp;rft.aufirst=Dan&amp;rft.aulast=Carden&amp;rft.date=2015-08-17&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.nwitimes.com%2Fnews%2Flocal%2Fgovt-and-politics%2Felections%2Ftallian-drops-out-of-governor-s-race%2Farticle_73b5ffef-4ce1-536c-9825-568ca5d660a4.html&amp;rft.jtitle=The+Times+of+Northwest+Indiana&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-INFT-78"><span class="mw-cite-backlink">^ <a href="#cite_ref-INFT_78-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-INFT_78-1"><sup><i><b>b</b></i></sup></a></span> <span class="reference-text"><cite class="citation news">Livingston, Abby (June 19, 2013). <a rel="nofollow" class="external text" href="http://www.rollcall.com/news/ambitious_hoosiers_wait_for_future_statewide_races_farm_team-225788-1.html">"Ambitious Hoosiers Wait for Future Statewide Races | Farm Team"</a>. <i>Roll Call</i><span class="reference-accessdate">. Retrieved <span class="nowrap">April 3,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Ambitious+Hoosiers+Wait+for+Future+Statewide+Races+%7C+Farm+Team&amp;rft.aufirst=Abby&amp;rft.aulast=Livingston&amp;rft.date=2013-06-19&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.rollcall.com%2Fnews%2Fambitious_hoosiers_wait_for_future_statewide_races_farm_team-225788-1.html&amp;rft.jtitle=Roll+Call&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-greggdrops-79"><span class="mw-cite-backlink"><b><a href="#cite_ref-greggdrops_79-0">^</a></b></span> <span class="reference-text"><cite class="citation web">Norman Cox (October 23, 2013). <a rel="nofollow" class="external text" href="http://www.theindychannel.com/news/local-news/dem-john-gregg-drops-out-of-2016-indiana-governors-race">"Dem. John Gregg drops out of 2016 Indiana governor's race"</a>. <i>The Indy Channel</i><span class="reference-accessdate">. Retrieved <span class="nowrap">October 24,</span> 2013</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Dem.+John+Gregg+drops+out+of+2016+Indiana+governor%27s+race&amp;rft.au=Norman+Cox&amp;rft.date=2013-10-23&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.theindychannel.com%2Fnews%2Flocal-news%2Fdem-john-gregg-drops-out-of-2016-indiana-governors-race&amp;rft.jtitle=The+Indy+Channel&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-bayhnot-80"><span class="mw-cite-backlink"><b><a href="#cite_ref-bayhnot_80-0">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.nwitimes.com/news/local/govt-and-politics/bayh-not-running-for-governor-in/article_f1c06cff-259c-5fa6-a3cb-1fe418e3fe62.html">"Bayh not running for governor in 2016"</a>. nwi.com. September 13, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">October 26,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Bayh+not+running+for+governor+in+2016&amp;rft.date=2014-09-13&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.nwitimes.com%2Fnews%2Flocal%2Fgovt-and-politics%2Fbayh-not-running-for-governor-in%2Farticle_f1c06cff-259c-5fa6-a3cb-1fe418e3fe62.html&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-gauging-81"><span class="mw-cite-backlink"><b><a href="#cite_ref-gauging_81-0">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://howeypolitics.com/Content/Columns/David-Kitchell/Article/Dave-Kitchell--Gauging-a-potential-2016-Democrat-ticket/10/22/10561">"Dave Kitchell: Gauging a potential 2016 Democrat ticket"</a>. Howey Politics Indiana. November 4, 2013<span class="reference-accessdate">. Retrieved <span class="nowrap">October 26,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Dave+Kitchell%3A+Gauging+a+potential+2016+Democrat+ticket&amp;rft.date=2013-11-04&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fhoweypolitics.com%2FContent%2FColumns%2FDavid-Kitchell%2FArticle%2FDave-Kitchell--Gauging-a-potential-2016-Democrat-ticket%2F10%2F22%2F10561&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-searching-82"><span class="mw-cite-backlink"><b><a href="#cite_ref-searching_82-0">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.indystar.com/story/opinion/columnists/russ-pulliam/2014/02/21/indiana-democrats-searching-for-gubernatorial-candidates/5691961/">"Indiana Democrats searching for gubernatorial candidates"</a>. IndyStar.com. February 21, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">October 26,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Indiana+Democrats+searching+for+gubernatorial+candidates&amp;rft.date=2014-02-21&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.indystar.com%2Fstory%2Fopinion%2Fcolumnists%2Fruss-pulliam%2F2014%2F02%2F21%2Findiana-democrats-searching-for-gubernatorial-candidates%2F5691961%2F&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-83"><span class="mw-cite-backlink"><b><a href="#cite_ref-83">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.howeypolitics.com/Content/Default/Lead-Story/Article/Evan-Bayh-won-t-seek-the-governorship-in-2016/-3/346/11786">"Evan Bayh won't run in 2016; Gregg, McDermott assess"</a>. Howey Politics. September 15, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">September 12,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Evan+Bayh+won%27t+run+in+2016%3B+Gregg%2C+McDermott+assess&amp;rft.date=2014-09-15&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.howeypolitics.com%2FContent%2FDefault%2FLead-Story%2FArticle%2FEvan-Bayh-won-t-seek-the-governorship-in-2016%2F-3%2F346%2F11786&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-84"><span class="mw-cite-backlink"><b><a href="#cite_ref-84">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.indystar.com/story/news/politics/2016/07/13/bayh-makes-senate-bid-official/87026058/">"Evan Bayh on running for Senate, Indiana residency"</a>. <i>indystar.com</i><span class="reference-accessdate">. Retrieved <span class="nowrap">August 2,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Evan+Bayh+on+running+for+Senate%2C+Indiana+residency&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.indystar.com%2Fstory%2Fnews%2Fpolitics%2F2016%2F07%2F13%2Fbayh-makes-senate-bid-official%2F87026058%2F&amp;rft.jtitle=indystar.com&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-85"><span class="mw-cite-backlink"><b><a href="#cite_ref-85">^</a></b></span> <span class="reference-text"><cite class="citation web">Wilson, Reid (February 13, 2015). <a rel="nofollow" class="external text" href="http://www.washingtonpost.com/blogs/govbeat/wp/2015/02/13/oregons-new-governor-helped-usher-kitzhaber-out/">"Oregon's new governor helped usher Kitzhaber out"</a>. <i>The Washington Post</i><span class="reference-accessdate">. Retrieved <span class="nowrap">February 13,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Oregon%27s+new+governor+helped+usher+Kitzhaber+out&amp;rft.aufirst=Reid&amp;rft.aulast=Wilson&amp;rft.date=2015-02-13&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.washingtonpost.com%2Fblogs%2Fgovbeat%2Fwp%2F2015%2F02%2F13%2Foregons-new-governor-helped-usher-kitzhaber-out%2F&amp;rft.jtitle=The+Washington+Post&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-86"><span class="mw-cite-backlink"><b><a href="#cite_ref-86">^</a></b></span> <span class="reference-text">Theriault, Denis C. (September 18, 2015) <a rel="nofollow" class="external text" href="http://www.oregonlive.com/politics/index.ssf/2015/09/kate_brown_lets_it_buck_in_pen.html">"Kate Brown makes clear she's running for governor"</a>, <i><a href="/wiki/The_Oregonian" title="The Oregonian">The Oregonian</a></i>. Retrieved September 18, 2015.</span></li>
+<li id="cite_note-theriault-87"><span class="mw-cite-backlink"><b><a href="#cite_ref-theriault_87-0">^</a></b></span> <span class="reference-text"><cite class="citation web">Theriault, Denis C. (March 7, 2016). <a rel="nofollow" class="external text" href="http://www.oregonlive.com/politics/index.ssf/2016/03/shakeup_in_governors_race_alle.html">"Shakeup in governor's race: Allen Alley wants Republican nomination"</a>. <i><a href="/wiki/The_Oregonian" title="The Oregonian">The Oregonian</a></i><span class="reference-accessdate">. Retrieved <span class="nowrap">March 7,</span> 2016</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Shakeup+in+governor%27s+race%3A+Allen+Alley+wants+Republican+nomination&amp;rft.aufirst=Denis+C.&amp;rft.aulast=Theriault&amp;rft.date=2016-03-07&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.oregonlive.com%2Fpolitics%2Findex.ssf%2F2016%2F03%2Fshakeup_in_governors_race_alle.html&amp;rft.jtitle=The+Oregonian&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-ewhitney-88"><span class="mw-cite-backlink"><b><a href="#cite_ref-ewhitney_88-0">^</a></b></span> <span class="reference-text"><cite class="citation news">Whitney, Eric (September 28, 2015). <a rel="nofollow" class="external text" href="http://mtpr.org/post/brad-johnson-explains-why-hes-running-governor-montana">"Brad Johnson Explains Why He's Running For Governor Of Montana"</a>. Montana Public Radio<span class="reference-accessdate">. Retrieved <span class="nowrap">September 29,</span> 2015</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Brad+Johnson+Explains+Why+He%27s+Running+For+Governor+Of+Montana&amp;rft.aufirst=Eric&amp;rft.aulast=Whitney&amp;rft.date=2015-09-28&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fmtpr.org%2Fpost%2Fbrad-johnson-explains-why-hes-running-governor-montana&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-89"><span class="mw-cite-backlink"><b><a href="#cite_ref-89">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.bozemandailychronicle.com/news/politics/ag-tim-fox-files-paperwork-for-re-election-in/article_f16024e0-6b98-11e4-b30f-8f66281cf801.html">"AG Tim Fox files paperwork for re-election in 2016"</a>. The Bozeman Daily Chronicle. November 13, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">November 15,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.btitle=AG+Tim+Fox+files+paperwork+for+re-election+in+2016&amp;rft.date=2014-11-13&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.bozemandailychronicle.com%2Fnews%2Fpolitics%2Fag-tim-fox-files-paperwork-for-re-election-in%2Farticle_f16024e0-6b98-11e4-b30f-8f66281cf801.html&amp;rft.pub=The+Bozeman+Daily+Chronicle&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-what2014-90"><span class="mw-cite-backlink">^ <a href="#cite_ref-what2014_90-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-what2014_90-1"><sup><i><b>b</b></i></sup></a></span> <span class="reference-text"><cite class="citation news">Connelly, Joe (September 29, 2014). <a rel="nofollow" class="external text" href="http://blog.seattlepi.com/seattlepolitics/2014/09/29/what-will-2014-elections-tell-us-about-our-2016-governors-race/">"What 2014 elections say about 2016 governor's race"</a>. <i><a href="/wiki/Seattle_Post-Intelligencer" title="Seattle Post-Intelligencer">Seattlepi</a></i><span class="reference-accessdate">. Retrieved <span class="nowrap">October 2,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=What+2014+elections+say+about+2016+governor%27s+race&amp;rft.aufirst=Joe&amp;rft.aulast=Connelly&amp;rft.date=2014-09-29&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fblog.seattlepi.com%2Fseattlepolitics%2F2014%2F09%2F29%2Fwhat-will-2014-elections-tell-us-about-our-2016-governors-race%2F&amp;rft.jtitle=Seattlepi&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-McKenna-91"><span class="mw-cite-backlink"><b><a href="#cite_ref-McKenna_91-0">^</a></b></span> <span class="reference-text"><cite class="citation news">Rosenthal, Brian (February 19, 2013). <a rel="nofollow" class="external text" href="http://www.yakimaherald.com/news/yhr/wednesday/854831-8/former-ag-mckenna-joins-law-firm">"Former AG McKenna joins law firm"</a>. <i>Yakia Herald</i><span class="reference-accessdate">. Retrieved <span class="nowrap">March 4,</span> 2013</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Former+AG+McKenna+joins+law+firm&amp;rft.aufirst=Brian&amp;rft.aulast=Rosenthal&amp;rft.date=2013-02-19&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.yakimaherald.com%2Fnews%2Fyhr%2Fwednesday%2F854831-8%2Fformer-ag-mckenna-joins-law-firm&amp;rft.jtitle=Yakia+Herald&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-92"><span class="mw-cite-backlink"><b><a href="#cite_ref-92">^</a></b></span> <span class="reference-text"><cite class="citation news">Cornfield, Jerry (June 6, 2013). <a rel="nofollow" class="external text" href="http://www.heraldnet.com/article/20130606/NEWS01/706069918">"If not McKenna, others could challenge Inslee in 2016"</a>. <i><a href="/wiki/The_Herald_(Everett)" title="The Herald (Everett)">HeraldNet</a></i><span class="reference-accessdate">. Retrieved <span class="nowrap">July 10,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=If+not+McKenna%2C+others+could+challenge+Inslee+in+2016&amp;rft.aufirst=Jerry&amp;rft.aulast=Cornfield&amp;rft.date=2013-06-06&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.heraldnet.com%2Farticle%2F20130606%2FNEWS01%2F706069918&amp;rft.jtitle=HeraldNet&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-realclear-93"><span class="mw-cite-backlink"><b><a href="#cite_ref-realclear_93-0">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.realclearpolitics.com/news/ap/politics/2012/Sep/04/6_candidates_vie_to_be_american_samoa_s_governor.html">"6 candidates vie to be American Samoa's governor"</a>. <a href="/wiki/Real_Clear_Politics" class="mw-redirect" title="Real Clear Politics">Real Clear Politics</a>. Associated Press. September 4, 2012<span class="reference-accessdate">. Retrieved <span class="nowrap">November 1,</span> 2012</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=6+candidates+vie+to+be+American+Samoa%27s+governor&amp;rft.date=2012-09-04&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.realclearpolitics.com%2Fnews%2Fap%2Fpolitics%2F2012%2FSep%2F04%2F6_candidates_vie_to_be_american_samoa_s_governor.html&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-launches-94"><span class="mw-cite-backlink"><b><a href="#cite_ref-launches_94-0">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.newsobserver.com/2014/12/02/4370719_gov-pat-mccrory-launches-2016.html">"Gov. Pat McCrory launches 2016 campaign"</a>. The News &amp; Observer. December 2, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">December 5,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.btitle=Gov.+Pat+McCrory+launches+2016+campaign&amp;rft.date=2014-12-02&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.newsobserver.com%2F2014%2F12%2F02%2F4370719_gov-pat-mccrory-launches-2016.html&amp;rft.pub=The+News+%26+Observer&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-95"><span class="mw-cite-backlink"><b><a href="#cite_ref-95">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.wfmynews2.com/story/news/local/2014/11/06/roy-cooper-for-governor/18594755/">"Attorney General Announces Candidacy For Governor"</a>. <i>Charlotte Observer</i>. November 6, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">November 7,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Attorney+General+Announces+Candidacy+For+Governor&amp;rft.date=2014-11-06&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.wfmynews2.com%2Fstory%2Fnews%2Flocal%2F2014%2F11%2F06%2Froy-cooper-for-governor%2F18594755%2F&amp;rft.jtitle=Charlotte+Observer&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-Eye-96"><span class="mw-cite-backlink">^ <a href="#cite_ref-Eye_96-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-Eye_96-1"><sup><i><b>b</b></i></sup></a></span> <span class="reference-text"><cite class="citation web">Reid Wilson (September 6, 2013). <a rel="nofollow" class="external text" href="http://www.washingtonpost.com/blogs/govbeat/wp/2013/09/06/three-years-out-democrats-eye-mccrorys-seat/">"Three years out, Democrats eye McCrory's seat"</a>. <i><a href="/wiki/The_Washington_Post" title="The Washington Post">The Washington Post</a></i><span class="reference-accessdate">. Retrieved <span class="nowrap">September 9,</span> 2013</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Three+years+out%2C+Democrats+eye+McCrory%27s+seat&amp;rft.au=Reid+Wilson&amp;rft.date=2013-09-06&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.washingtonpost.com%2Fblogs%2Fgovbeat%2Fwp%2F2013%2F09%2F06%2Fthree-years-out-democrats-eye-mccrorys-seat%2F&amp;rft.jtitle=The+Washington+Post&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-97"><span class="mw-cite-backlink"><b><a href="#cite_ref-97">^</a></b></span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.newsobserver.com/2013/10/17/3289581/protzman-drops-out-of-governors.html">"Protzman drops out of governor's race after 7 months"</a>. <i><a href="/wiki/The_News_%26_Observer" title="The News &amp; Observer">The News &amp; Observer</a></i>. October 17, 2013<span class="reference-accessdate">. Retrieved <span class="nowrap">November 28,</span> 2013</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Protzman+drops+out+of+governor%27s+race+after+7+months&amp;rft.date=2013-10-17&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.newsobserver.com%2F2013%2F10%2F17%2F3289581%2Fprotzman-drops-out-of-governors.html&amp;rft.jtitle=The+News+%26+Observer&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-herbertsays-98"><span class="mw-cite-backlink">^ <a href="#cite_ref-herbertsays_98-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-herbertsays_98-1"><sup><i><b>b</b></i></sup></a></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.sltrib.com/sltrib/politics/58113805-90/herbert-governor-2016-gov.html.csp">"Governor Herbert says he will run for re-election in 2016"</a>. <i>The Salt Lake Tribune</i>. June 25, 2014<span class="reference-accessdate">. Retrieved <span class="nowrap">August 22,</span> 2014</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Governor+Herbert+says+he+will+run+for+re-election+in+2016&amp;rft.date=2014-06-25&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.sltrib.com%2Fsltrib%2Fpolitics%2F58113805-90%2Fherbert-governor-2016-gov.html.csp&amp;rft.jtitle=The+Salt+Lake+Tribune&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-tech-99"><span class="mw-cite-backlink"><b><a href="#cite_ref-tech_99-0">^</a></b></span> <span class="reference-text"><cite class="citation news"><a rel="nofollow" class="external text" href="http://www.sltrib.com/sltrib/politics/57292201-90/matheson-utah-governor-run.html.csp">"Is a run for governor or Senate in Matheson's future?"</a>. <i>The Salt Lake Tribune</i>. December 23, 2013<span class="reference-accessdate">. Retrieved <span class="nowrap">December 24,</span> 2013</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AUnited+States+gubernatorial+elections%2C+2016&amp;rft.atitle=Is+a+run+for+governor+or+Senate+in+Matheson%27s+future%3F&amp;rft.date=2013-12-23&amp;rft.genre=article&amp;rft_id=http%3A%2F%2Fwww.sltrib.com%2Fsltrib%2Fpolitics%2F57292201-90%2Fmatheson-utah-governor-run.html.csp&amp;rft.jtitle=The+Salt+Lake+Tribune&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+</ol>
+</div>
+<div role="navigation" class="navbox" aria-labelledby=".282015_.E2.86.90.29_.C2.A0_2016_United_States_elections_.C2.A0_.28.E2.86.92_2017.29" style="padding:3px">
+<table class="nowraplinks hlist collapsible autocollapse navbox-inner" style="border-spacing:0;background:transparent;color:inherit">
+<tr>
+<th scope="col" class="navbox-title" colspan="2">
+<div class="plainlinks hlist navbar mini">
+<ul>
+<li class="nv-view"><a href="/wiki/Template:United_States_elections,_2016" title="Template:United States elections, 2016"><abbr title="View this template" style=";;background:none transparent;border:none;">v</abbr></a></li>
+<li class="nv-talk"><a href="/wiki/Template_talk:United_States_elections,_2016" title="Template talk:United States elections, 2016"><abbr title="Discuss this template" style=";;background:none transparent;border:none;">t</abbr></a></li>
+<li class="nv-edit"><a class="external text" href="//en.wikipedia.org/w/index.php?title=Template:United_States_elections,_2016&amp;action=edit"><abbr title="Edit this template" style=";;background:none transparent;border:none;">e</abbr></a></li>
+</ul>
+</div>
+<div id=".282015_.E2.86.90.29_.C2.A0_2016_United_States_elections_.C2.A0_.28.E2.86.92_2017.29" style="font-size:114%">(<a href="/wiki/United_States_elections,_2015" title="United States elections, 2015">2015 ←</a>) &#160; <a href="/wiki/United_States_elections,_2016" title="United States elections, 2016">2016 United States elections</a> &#160; (<a href="/wiki/United_States_elections,_2017" title="United States elections, 2017">→ 2017</a>)</div>
+</th>
+</tr>
+<tr style="height:2px">
+<td colspan="2"></td>
+</tr>
+<tr>
+<th scope="row" class="navbox-group"><a href="/wiki/United_States_presidential_election,_2016" title="United States presidential election, 2016">U.S.<br />
+President</a></th>
+<td class="navbox-list navbox-odd" style="text-align:left;border-left-width:2px;border-left-style:solid;width:100%;padding:0px">
+<div style="padding:0em 0.25em">
+<ul>
+<li><a href="/wiki/United_States_presidential_election_in_Alabama,_2016" title="United States presidential election in Alabama, 2016">Alabama</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Alaska,_2016" title="United States presidential election in Alaska, 2016">Alaska</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Arizona,_2016" title="United States presidential election in Arizona, 2016">Arizona</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Arkansas,_2016" title="United States presidential election in Arkansas, 2016">Arkansas</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_California,_2016" title="United States presidential election in California, 2016">California</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Colorado,_2016" title="United States presidential election in Colorado, 2016">Colorado</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Connecticut,_2016" title="United States presidential election in Connecticut, 2016">Connecticut</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Delaware,_2016" title="United States presidential election in Delaware, 2016">Delaware</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_the_District_of_Columbia,_2016" title="United States presidential election in the District of Columbia, 2016">District of Columbia</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Florida,_2016" title="United States presidential election in Florida, 2016">Florida</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Georgia,_2016" title="United States presidential election in Georgia, 2016">Georgia</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Hawaii,_2016" title="United States presidential election in Hawaii, 2016">Hawaii</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Idaho,_2016" title="United States presidential election in Idaho, 2016">Idaho</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Illinois,_2016" title="United States presidential election in Illinois, 2016">Illinois</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Indiana,_2016" title="United States presidential election in Indiana, 2016">Indiana</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Iowa,_2016" title="United States presidential election in Iowa, 2016">Iowa</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Kansas,_2016" title="United States presidential election in Kansas, 2016">Kansas</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Kentucky,_2016" title="United States presidential election in Kentucky, 2016">Kentucky</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Louisiana,_2016" title="United States presidential election in Louisiana, 2016">Louisiana</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Maine,_2016" title="United States presidential election in Maine, 2016">Maine</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Maryland,_2016" title="United States presidential election in Maryland, 2016">Maryland</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Massachusetts,_2016" title="United States presidential election in Massachusetts, 2016">Massachusetts</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Michigan,_2016" title="United States presidential election in Michigan, 2016">Michigan</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Minnesota,_2016" title="United States presidential election in Minnesota, 2016">Minnesota</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Mississippi,_2016" title="United States presidential election in Mississippi, 2016">Mississippi</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Missouri,_2016" title="United States presidential election in Missouri, 2016">Missouri</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Montana,_2016" title="United States presidential election in Montana, 2016">Montana</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Nebraska,_2016" title="United States presidential election in Nebraska, 2016">Nebraska</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Nevada,_2016" title="United States presidential election in Nevada, 2016">Nevada</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_New_Hampshire,_2016" title="United States presidential election in New Hampshire, 2016">New Hampshire</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_New_Jersey,_2016" title="United States presidential election in New Jersey, 2016">New Jersey</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_New_Mexico,_2016" title="United States presidential election in New Mexico, 2016">New Mexico</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_New_York,_2016" title="United States presidential election in New York, 2016">New York</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_North_Carolina,_2016" title="United States presidential election in North Carolina, 2016">North Carolina</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_North_Dakota,_2016" title="United States presidential election in North Dakota, 2016">North Dakota</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Ohio,_2016" title="United States presidential election in Ohio, 2016">Ohio</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Oklahoma,_2016" title="United States presidential election in Oklahoma, 2016">Oklahoma</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Oregon,_2016" title="United States presidential election in Oregon, 2016">Oregon</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Pennsylvania,_2016" title="United States presidential election in Pennsylvania, 2016">Pennsylvania</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Rhode_Island,_2016" title="United States presidential election in Rhode Island, 2016">Rhode Island</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_South_Carolina,_2016" title="United States presidential election in South Carolina, 2016">South Carolina</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_South_Dakota,_2016" title="United States presidential election in South Dakota, 2016">South Dakota</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Tennessee,_2016" title="United States presidential election in Tennessee, 2016">Tennessee</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Texas,_2016" title="United States presidential election in Texas, 2016">Texas</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Utah,_2016" title="United States presidential election in Utah, 2016">Utah</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Vermont,_2016" title="United States presidential election in Vermont, 2016">Vermont</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Virginia,_2016" title="United States presidential election in Virginia, 2016">Virginia</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Washington_(state),_2016" title="United States presidential election in Washington (state), 2016">Washington</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_West_Virginia,_2016" title="United States presidential election in West Virginia, 2016">West Virginia</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Wisconsin,_2016" title="United States presidential election in Wisconsin, 2016">Wisconsin</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Wyoming,_2016" title="United States presidential election in Wyoming, 2016">Wyoming</a></li>
+</ul>
+<ul>
+<li><a href="/wiki/United_States_presidential_election_in_American_Samoa,_2016" title="United States presidential election in American Samoa, 2016">American Samoa</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Guam,_2016" title="United States presidential election in Guam, 2016">Guam</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_the_Northern_Mariana_Islands,_2016" title="United States presidential election in the Northern Mariana Islands, 2016">Northern Mariana Islands</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_Puerto_Rico,_2016" class="mw-redirect" title="United States presidential election in Puerto Rico, 2016">Puerto Rico</a></li>
+<li><a href="/wiki/United_States_presidential_election_in_the_US_Virgin_Islands,_2016" title="United States presidential election in the US Virgin Islands, 2016">U.S. Virgin Islands</a></li>
+</ul>
+</div>
+</td>
+</tr>
+<tr style="height:2px">
+<td colspan="2"></td>
+</tr>
+<tr>
+<th scope="row" class="navbox-group"><a href="/wiki/United_States_Senate_elections,_2016" title="United States Senate elections, 2016">U.S.<br />
+Senate</a></th>
+<td class="navbox-list navbox-even" style="text-align:left;border-left-width:2px;border-left-style:solid;width:100%;padding:0px">
+<div style="padding:0em 0.25em">
+<ul>
+<li><a href="/wiki/United_States_Senate_election_in_Alabama,_2016" title="United States Senate election in Alabama, 2016">Alabama</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Alaska,_2016" title="United States Senate election in Alaska, 2016">Alaska</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Arizona,_2016" title="United States Senate election in Arizona, 2016">Arizona</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Arkansas,_2016" title="United States Senate election in Arkansas, 2016">Arkansas</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_California,_2016" title="United States Senate election in California, 2016">California</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Colorado,_2016" title="United States Senate election in Colorado, 2016">Colorado</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Connecticut,_2016" title="United States Senate election in Connecticut, 2016">Connecticut</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Florida,_2016" title="United States Senate election in Florida, 2016">Florida</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Georgia,_2016" title="United States Senate election in Georgia, 2016">Georgia</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Hawaii,_2016" title="United States Senate election in Hawaii, 2016">Hawaii</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Idaho,_2016" title="United States Senate election in Idaho, 2016">Idaho</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Illinois,_2016" title="United States Senate election in Illinois, 2016">Illinois</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Indiana,_2016" title="United States Senate election in Indiana, 2016">Indiana</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Iowa,_2016" title="United States Senate election in Iowa, 2016">Iowa</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Kansas,_2016" title="United States Senate election in Kansas, 2016">Kansas</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Kentucky,_2016" title="United States Senate election in Kentucky, 2016">Kentucky</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Louisiana,_2016" title="United States Senate election in Louisiana, 2016">Louisiana</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Maryland,_2016" title="United States Senate election in Maryland, 2016">Maryland</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Missouri,_2016" title="United States Senate election in Missouri, 2016">Missouri</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Nevada,_2016" title="United States Senate election in Nevada, 2016">Nevada</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_New_Hampshire,_2016" title="United States Senate election in New Hampshire, 2016">New Hampshire</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_New_York,_2016" title="United States Senate election in New York, 2016">New York</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_North_Carolina,_2016" title="United States Senate election in North Carolina, 2016">North Carolina</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_North_Dakota,_2016" title="United States Senate election in North Dakota, 2016">North Dakota</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Ohio,_2016" title="United States Senate election in Ohio, 2016">Ohio</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Oklahoma,_2016" title="United States Senate election in Oklahoma, 2016">Oklahoma</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Oregon,_2016" title="United States Senate election in Oregon, 2016">Oregon</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Pennsylvania,_2016" title="United States Senate election in Pennsylvania, 2016">Pennsylvania</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_South_Carolina,_2016" title="United States Senate election in South Carolina, 2016">South Carolina</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_South_Dakota,_2016" title="United States Senate election in South Dakota, 2016">South Dakota</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Utah,_2016" title="United States Senate election in Utah, 2016">Utah</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Vermont,_2016" title="United States Senate election in Vermont, 2016">Vermont</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Washington,_2016" title="United States Senate election in Washington, 2016">Washington</a></li>
+<li><a href="/wiki/United_States_Senate_election_in_Wisconsin,_2016" title="United States Senate election in Wisconsin, 2016">Wisconsin</a></li>
+</ul>
+</div>
+</td>
+</tr>
+<tr style="height:2px">
+<td colspan="2"></td>
+</tr>
+<tr>
+<th scope="row" class="navbox-group"><a href="/wiki/United_States_House_of_Representatives_elections,_2016" title="United States House of Representatives elections, 2016">U.S.<br />
+House</a></th>
+<td class="navbox-list navbox-odd" style="text-align:left;border-left-width:2px;border-left-style:solid;width:100%;padding:0px">
+<div style="padding:0em 0.25em">
+<ul>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Alabama,_2016" title="United States House of Representatives elections in Alabama, 2016">Alabama</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_election_in_Alaska,_2016" title="United States House of Representatives election in Alaska, 2016">Alaska</a></li>
+<li><a href="/w/index.php?title=United_States_House_of_Representatives_election_in_American_Samoa,_2016&amp;action=edit&amp;redlink=1" class="new" title="United States House of Representatives election in American Samoa, 2016 (page does not exist)">American Samoa</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Arizona,_2016" title="United States House of Representatives elections in Arizona, 2016">Arizona</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Arkansas,_2016" title="United States House of Representatives elections in Arkansas, 2016">Arkansas</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_California,_2016" title="United States House of Representatives elections in California, 2016">California</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Colorado,_2016" title="United States House of Representatives elections in Colorado, 2016">Colorado</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Connecticut,_2016" title="United States House of Representatives elections in Connecticut, 2016">Connecticut</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_election_in_Delaware,_2016" title="United States House of Representatives election in Delaware, 2016">Delaware</a></li>
+<li><a href="/w/index.php?title=United_States_House_of_Representatives_election_in_the_District_of_Columbia,_2016&amp;action=edit&amp;redlink=1" class="new" title="United States House of Representatives election in the District of Columbia, 2016 (page does not exist)">District of Columbia</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Florida,_2016" title="United States House of Representatives elections in Florida, 2016">Florida</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Georgia,_2016" title="United States House of Representatives elections in Georgia, 2016">Georgia</a></li>
+<li><a href="/w/index.php?title=United_States_House_of_Representatives_election_in_Guam,_2016&amp;action=edit&amp;redlink=1" class="new" title="United States House of Representatives election in Guam, 2016 (page does not exist)">Guam</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Hawaii,_2016" title="United States House of Representatives elections in Hawaii, 2016">Hawaii</a>
+<ul>
+<li><a href="/wiki/Hawaii%27s_1st_congressional_district_special_election,_2016" title="Hawaii's 1st congressional district special election, 2016">1st (special)</a></li>
+</ul>
+</li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Idaho,_2016" title="United States House of Representatives elections in Idaho, 2016">Idaho</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Illinois,_2016" title="United States House of Representatives elections in Illinois, 2016">Illinois</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Indiana,_2016" title="United States House of Representatives elections in Indiana, 2016">Indiana</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Iowa,_2016" title="United States House of Representatives elections in Iowa, 2016">Iowa</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Kansas,_2016" title="United States House of Representatives elections in Kansas, 2016">Kansas</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Kentucky,_2016" title="United States House of Representatives elections in Kentucky, 2016">Kentucky</a>
+<ul>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Kentucky,_2016#Special_election" title="United States House of Representatives elections in Kentucky, 2016">1st (special)</a></li>
+</ul>
+</li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Louisiana,_2016" title="United States House of Representatives elections in Louisiana, 2016">Louisiana</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Maine,_2016" title="United States House of Representatives elections in Maine, 2016">Maine</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Maryland,_2016" title="United States House of Representatives elections in Maryland, 2016">Maryland</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Massachusetts,_2016" title="United States House of Representatives elections in Massachusetts, 2016">Massachusetts</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Michigan,_2016" title="United States House of Representatives elections in Michigan, 2016">Michigan</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Minnesota,_2016" title="United States House of Representatives elections in Minnesota, 2016">Minnesota</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Mississippi,_2016" title="United States House of Representatives elections in Mississippi, 2016">Mississippi</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Missouri,_2016" title="United States House of Representatives elections in Missouri, 2016">Missouri</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_election_in_Montana,_2016" title="United States House of Representatives election in Montana, 2016">Montana</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Nebraska,_2016" title="United States House of Representatives elections in Nebraska, 2016">Nebraska</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Nevada,_2016" title="United States House of Representatives elections in Nevada, 2016">Nevada</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_New_Hampshire,_2016" title="United States House of Representatives elections in New Hampshire, 2016">New Hampshire</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_New_Jersey,_2016" title="United States House of Representatives elections in New Jersey, 2016">New Jersey</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_New_Mexico,_2016" title="United States House of Representatives elections in New Mexico, 2016">New Mexico</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_New_York,_2016" title="United States House of Representatives elections in New York, 2016">New York</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_North_Carolina,_2016" title="United States House of Representatives elections in North Carolina, 2016">North Carolina</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_election_in_North_Dakota,_2016" title="United States House of Representatives election in North Dakota, 2016">North Dakota</a></li>
+<li><a href="/w/index.php?title=United_States_House_of_Representatives_election_in_the_Northern_Mariana_Islands,_2016&amp;action=edit&amp;redlink=1" class="new" title="United States House of Representatives election in the Northern Mariana Islands, 2016 (page does not exist)">Northern Mariana Islands</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Ohio,_2016" title="United States House of Representatives elections in Ohio, 2016">Ohio</a>
+<ul>
+<li><a href="/wiki/Ohio%27s_8th_congressional_district_special_election,_2016" title="Ohio's 8th congressional district special election, 2016">8th (special)</a></li>
+</ul>
+</li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Oklahoma,_2016" title="United States House of Representatives elections in Oklahoma, 2016">Oklahoma</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Oregon,_2016" title="United States House of Representatives elections in Oregon, 2016">Oregon</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Pennsylvania,_2016" title="United States House of Representatives elections in Pennsylvania, 2016">Pennsylvania</a>
+<ul>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Pennsylvania,_2016#Special_election" title="United States House of Representatives elections in Pennsylvania, 2016">2nd (special)</a></li>
+</ul>
+</li>
+<li><a href="/wiki/United_States_House_of_Representatives_election_in_Puerto_Rico,_2016" title="United States House of Representatives election in Puerto Rico, 2016">Puerto Rico</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Rhode_Island,_2016" title="United States House of Representatives elections in Rhode Island, 2016">Rhode Island</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_South_Carolina,_2016" title="United States House of Representatives elections in South Carolina, 2016">South Carolina</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_election_in_South_Dakota,_2016" title="United States House of Representatives election in South Dakota, 2016">South Dakota</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Tennessee,_2016" title="United States House of Representatives elections in Tennessee, 2016">Tennessee</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Texas,_2016" title="United States House of Representatives elections in Texas, 2016">Texas</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Utah,_2016" title="United States House of Representatives elections in Utah, 2016">Utah</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_election_in_Vermont,_2016" title="United States House of Representatives election in Vermont, 2016">Vermont</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Virginia,_2016" title="United States House of Representatives elections in Virginia, 2016">Virginia</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_election_in_the_United_States_Virgin_Islands,_2016" title="United States House of Representatives election in the United States Virgin Islands, 2016">U.S. Virgin Islands</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Washington,_2016" title="United States House of Representatives elections in Washington, 2016">Washington</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_West_Virginia,_2016" title="United States House of Representatives elections in West Virginia, 2016">West Virginia</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_elections_in_Wisconsin,_2016" title="United States House of Representatives elections in Wisconsin, 2016">Wisconsin</a></li>
+<li><a href="/wiki/United_States_House_of_Representatives_election_in_Wyoming,_2016" title="United States House of Representatives election in Wyoming, 2016">Wyoming</a></li>
+</ul>
+</div>
+</td>
+</tr>
+<tr style="height:2px">
+<td colspan="2"></td>
+</tr>
+<tr>
+<th scope="row" class="navbox-group"><strong class="selflink">Governors</strong></th>
+<td class="navbox-list navbox-even" style="text-align:left;border-left-width:2px;border-left-style:solid;width:100%;padding:0px">
+<div style="padding:0em 0.25em">
+<ul>
+<li><a href="/w/index.php?title=American_Samoa_American_Samoa_gubernatorial_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="American Samoa American Samoa gubernatorial election, 2016 (page does not exist)">American Samoa</a></li>
+<li><a href="/wiki/Delaware_gubernatorial_election,_2016" title="Delaware gubernatorial election, 2016">Delaware</a></li>
+<li><a href="/wiki/Indiana_gubernatorial_election,_2016" title="Indiana gubernatorial election, 2016">Indiana</a></li>
+<li><a href="/wiki/Missouri_gubernatorial_election,_2016" title="Missouri gubernatorial election, 2016">Missouri</a></li>
+<li><a href="/wiki/Montana_gubernatorial_election,_2016" title="Montana gubernatorial election, 2016">Montana</a></li>
+<li><a href="/wiki/New_Hampshire_gubernatorial_election,_2016" title="New Hampshire gubernatorial election, 2016">New Hampshire</a></li>
+<li><a href="/wiki/North_Carolina_gubernatorial_election,_2016" title="North Carolina gubernatorial election, 2016">North Carolina</a></li>
+<li><a href="/wiki/North_Dakota_gubernatorial_election,_2016" title="North Dakota gubernatorial election, 2016">North Dakota</a></li>
+<li><a href="/wiki/Oregon_gubernatorial_special_election,_2016" title="Oregon gubernatorial special election, 2016">Oregon (special)</a></li>
+<li><a href="/wiki/Puerto_Rico_gubernatorial_election,_2016" title="Puerto Rico gubernatorial election, 2016">Puerto Rico</a></li>
+<li><a href="/wiki/Utah_gubernatorial_election,_2016" title="Utah gubernatorial election, 2016">Utah</a></li>
+<li><a href="/wiki/Vermont_gubernatorial_election,_2016" title="Vermont gubernatorial election, 2016">Vermont</a></li>
+<li><a href="/wiki/Washington_gubernatorial_election,_2016" title="Washington gubernatorial election, 2016">Washington</a></li>
+<li><a href="/wiki/West_Virginia_gubernatorial_election,_2016" title="West Virginia gubernatorial election, 2016">West Virginia</a></li>
+</ul>
+</div>
+</td>
+</tr>
+<tr style="height:2px">
+<td colspan="2"></td>
+</tr>
+<tr>
+<th scope="row" class="navbox-group">Mayors</th>
+<td class="navbox-list navbox-odd" style="text-align:left;border-left-width:2px;border-left-style:solid;width:100%;padding:0px">
+<div style="padding:0em 0.25em">
+<ul>
+<li><a href="/w/index.php?title=Augusta_mayoral_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="Augusta mayoral election, 2016 (page does not exist)">Augusta</a></li>
+<li><a href="/wiki/Baltimore_mayoral_election,_2016" title="Baltimore mayoral election, 2016">Baltimore</a></li>
+<li><a href="/w/index.php?title=Cheyenne_mayoral_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="Cheyenne mayoral election, 2016 (page does not exist)">Cheyenne</a></li>
+<li><a href="/w/index.php?title=Fresno_mayoral_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="Fresno mayoral election, 2016 (page does not exist)">Fresno</a></li>
+<li><a href="/wiki/Honolulu_mayoral_election,_2016" title="Honolulu mayoral election, 2016">Honolulu</a></li>
+<li><a href="/w/index.php?title=Huntsville_mayoral_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="Huntsville mayoral election, 2016 (page does not exist)">Huntsville</a></li>
+<li><a href="/w/index.php?title=Juneau_mayoral_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="Juneau mayoral election, 2016 (page does not exist)">Juneau</a></li>
+<li><a href="/w/index.php?title=Mesa_mayoral_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="Mesa mayoral election, 2016 (page does not exist)">Mesa</a></li>
+<li><a href="/wiki/Milwaukee_mayoral_election,_2016" title="Milwaukee mayoral election, 2016">Milwaukee</a></li>
+<li><a href="/wiki/Portland,_Oregon_mayoral_election,_2016" title="Portland, Oregon mayoral election, 2016">Portland, Oregon</a></li>
+<li><a href="/wiki/Richmond_mayoral_election,_2016" title="Richmond mayoral election, 2016">Richmond</a></li>
+<li><a href="/w/index.php?title=Sacramento_mayoral_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="Sacramento mayoral election, 2016 (page does not exist)">Sacramento</a></li>
+<li><a href="/wiki/San_Diego_mayoral_election,_2016" title="San Diego mayoral election, 2016">San Diego</a></li>
+<li><a href="/w/index.php?title=San_Juan_mayoral_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="San Juan mayoral election, 2016 (page does not exist)">San Juan</a></li>
+<li><a href="/w/index.php?title=Scottsdale_mayoral_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="Scottsdale mayoral election, 2016 (page does not exist)">Scottsdale</a></li>
+<li><a href="/w/index.php?title=Virginia_Beach_mayoral_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="Virginia Beach mayoral election, 2016 (page does not exist)">Virginia Beach</a></li>
+<li><a href="/w/index.php?title=Wilmington_mayoral_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="Wilmington mayoral election, 2016 (page does not exist)">Wilmington</a></li>
+</ul>
+</div>
+</td>
+</tr>
+<tr style="height:2px">
+<td colspan="2"></td>
+</tr>
+<tr>
+<th scope="row" class="navbox-group"><a href="/w/index.php?title=United_States_state_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="United States state elections, 2016 (page does not exist)">States</a></th>
+<td class="navbox-list navbox-even" style="text-align:left;border-left-width:2px;border-left-style:solid;width:100%;padding:0px">
+<div style="padding:0em 0.25em">
+<ul>
+<li><a href="/w/index.php?title=Alabama_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Alabama elections, 2016 (page does not exist)">Alabama</a></li>
+<li><a href="/w/index.php?title=Alaska_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Alaska elections, 2016 (page does not exist)">Alaska</a></li>
+<li><a href="/w/index.php?title=American_Samoan_general_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="American Samoan general election, 2016 (page does not exist)">American Samoa</a></li>
+<li><a href="/w/index.php?title=Arizona_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Arizona elections, 2016 (page does not exist)">Arizona</a></li>
+<li><a href="/w/index.php?title=Arkansas_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Arkansas elections, 2016 (page does not exist)">Arkansas</a></li>
+<li><a href="/w/index.php?title=California_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="California elections, 2016 (page does not exist)">California</a></li>
+<li><a href="/w/index.php?title=Colorado_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Colorado elections, 2016 (page does not exist)">Colorado</a></li>
+<li><a href="/w/index.php?title=Connecticut_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Connecticut elections, 2016 (page does not exist)">Connecticut</a></li>
+<li><a href="/w/index.php?title=Delaware_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Delaware elections, 2016 (page does not exist)">Delaware</a></li>
+<li><a href="/w/index.php?title=Florida_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Florida elections, 2016 (page does not exist)">Florida</a></li>
+<li><a href="/w/index.php?title=Georgia_state_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Georgia state elections, 2016 (page does not exist)">Georgia</a></li>
+<li><a href="/w/index.php?title=Guamanian_general_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="Guamanian general election, 2016 (page does not exist)">Guam</a></li>
+<li><a href="/w/index.php?title=Hawaii_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Hawaii elections, 2016 (page does not exist)">Hawaii</a></li>
+<li><a href="/w/index.php?title=Idaho_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Idaho elections, 2016 (page does not exist)">Idaho</a></li>
+<li><a href="/w/index.php?title=Illinois_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Illinois elections, 2016 (page does not exist)">Illinois</a></li>
+<li><a href="/wiki/Indiana_elections,_2016" title="Indiana elections, 2016">Indiana</a></li>
+<li><a href="/wiki/Iowa_elections,_2016" title="Iowa elections, 2016">Iowa</a></li>
+<li><a href="/w/index.php?title=Kansas_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Kansas elections, 2016 (page does not exist)">Kansas</a></li>
+<li><a href="/w/index.php?title=Kentucky_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Kentucky elections, 2016 (page does not exist)">Kentucky</a></li>
+<li><a href="/w/index.php?title=Louisiana_state_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Louisiana state elections, 2016 (page does not exist)">Louisiana</a></li>
+<li><a href="/w/index.php?title=Maine_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Maine elections, 2016 (page does not exist)">Maine</a></li>
+<li><a href="/w/index.php?title=Maryland_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Maryland elections, 2016 (page does not exist)">Maryland</a></li>
+<li><a href="/w/index.php?title=Massachusetts_general_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="Massachusetts general election, 2016 (page does not exist)">Massachusetts</a></li>
+<li><a href="/w/index.php?title=Michigan_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Michigan elections, 2016 (page does not exist)">Michigan</a></li>
+<li><a href="/wiki/Minnesota_elections,_2016" title="Minnesota elections, 2016">Minnesota</a></li>
+<li><a href="/w/index.php?title=Mississippi_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Mississippi elections, 2016 (page does not exist)">Mississippi</a></li>
+<li><a href="/w/index.php?title=Missouri_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Missouri elections, 2016 (page does not exist)">Missouri</a></li>
+<li><a href="/w/index.php?title=Montana_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Montana elections, 2016 (page does not exist)">Montana</a></li>
+<li><a href="/w/index.php?title=Nebraska_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Nebraska elections, 2016 (page does not exist)">Nebraska</a></li>
+<li><a href="/wiki/Nevada_elections,_2016" title="Nevada elections, 2016">Nevada</a></li>
+<li><a href="/w/index.php?title=New_Hampshire_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="New Hampshire elections, 2016 (page does not exist)">New Hampshire</a></li>
+<li><a href="/w/index.php?title=New_Jersey_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="New Jersey elections, 2016 (page does not exist)">New Jersey</a></li>
+<li><a href="/w/index.php?title=New_Mexico_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="New Mexico elections, 2016 (page does not exist)">New Mexico</a></li>
+<li><a href="/w/index.php?title=New_York_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="New York elections, 2016 (page does not exist)">New York</a></li>
+<li><a href="/w/index.php?title=North_Carolina_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="North Carolina elections, 2016 (page does not exist)">North Carolina</a></li>
+<li><a href="/wiki/North_Dakota_elections,_2016" title="North Dakota elections, 2016">North Dakota</a></li>
+<li><a href="/wiki/Ohio_elections,_2016" title="Ohio elections, 2016">Ohio</a></li>
+<li><a href="/w/index.php?title=Oklahoma_state_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Oklahoma state elections, 2016 (page does not exist)">Oklahoma</a></li>
+<li><a href="/wiki/Oregon_elections,_2016" class="mw-redirect" title="Oregon elections, 2016">Oregon</a></li>
+<li><a href="/wiki/Pennsylvania_elections,_2016" class="mw-redirect" title="Pennsylvania elections, 2016">Pennsylvania</a></li>
+<li><a href="/wiki/Puerto_Rican_general_election,_2016" title="Puerto Rican general election, 2016">Puerto Rico</a></li>
+<li><a href="/w/index.php?title=Rhode_Island_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Rhode Island elections, 2016 (page does not exist)">Rhode Island</a></li>
+<li><a href="/w/index.php?title=South_Carolina_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="South Carolina elections, 2016 (page does not exist)">South Carolina</a></li>
+<li><a href="/w/index.php?title=South_Dakota_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="South Dakota elections, 2016 (page does not exist)">South Dakota</a></li>
+<li><a href="/w/index.php?title=Tennessee_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Tennessee elections, 2016 (page does not exist)">Tennessee</a></li>
+<li><a href="/w/index.php?title=Texas_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Texas elections, 2016 (page does not exist)">Texas</a></li>
+<li><a href="/wiki/Utah_elections,_2016" title="Utah elections, 2016">Utah</a></li>
+<li><a href="/w/index.php?title=Vermont_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Vermont elections, 2016 (page does not exist)">Vermont</a></li>
+<li><a href="/w/index.php?title=Virginia_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Virginia elections, 2016 (page does not exist)">Virginia</a></li>
+<li><a href="/w/index.php?title=United_States_Virgin_Islands_general_election,_2016&amp;action=edit&amp;redlink=1" class="new" title="United States Virgin Islands general election, 2016 (page does not exist)">U.S. Virgin Islands</a></li>
+<li><a href="/wiki/Washington_elections,_2016" title="Washington elections, 2016">Washington</a></li>
+<li><a href="/w/index.php?title=West_Virginia_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="West Virginia elections, 2016 (page does not exist)">West Virginia</a></li>
+<li><a href="/wiki/Wisconsin_elections,_2016" title="Wisconsin elections, 2016">Wisconsin</a></li>
+<li><a href="/w/index.php?title=Wyoming_elections,_2016&amp;action=edit&amp;redlink=1" class="new" title="Wyoming elections, 2016 (page does not exist)">Wyoming</a></li>
+</ul>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div role="navigation" class="navbox" aria-labelledby="Recent_United_States_gubernatorial_elections" style="padding:3px">
+<table class="nowraplinks hlist collapsible autocollapse navbox-inner" style="border-spacing:0;background:transparent;color:inherit">
+<tr>
+<th scope="col" class="navbox-title" colspan="2">
+<div class="plainlinks hlist navbar mini">
+<ul>
+<li class="nv-view"><a href="/wiki/Template:United_States_gubernatorial_elections" title="Template:United States gubernatorial elections"><abbr title="View this template" style=";;background:none transparent;border:none;">v</abbr></a></li>
+<li class="nv-talk"><a href="/wiki/Template_talk:United_States_gubernatorial_elections" title="Template talk:United States gubernatorial elections"><abbr title="Discuss this template" style=";;background:none transparent;border:none;">t</abbr></a></li>
+<li class="nv-edit"><a class="external text" href="//en.wikipedia.org/w/index.php?title=Template:United_States_gubernatorial_elections&amp;action=edit"><abbr title="Edit this template" style=";;background:none transparent;border:none;">e</abbr></a></li>
+</ul>
+</div>
+<div id="Recent_United_States_gubernatorial_elections" style="font-size:114%">Recent <a href="/wiki/Elections_in_the_United_States" title="Elections in the United States">United States gubernatorial elections</a></div>
+</th>
+</tr>
+<tr style="height:2px">
+<td colspan="2"></td>
+</tr>
+<tr>
+<td class="navbox-abovebelow" colspan="2">
+<div>
+<ul>
+<li><a href="/wiki/List_of_current_United_States_governors" title="List of current United States governors">List of current Governors</a></li>
+</ul>
+</div>
+</td>
+</tr>
+<tr style="height:2px">
+<td colspan="2"></td>
+</tr>
+<tr>
+<td colspan="2" class="navbox-list navbox-odd" style="width:100%;padding:0px">
+<div style="padding:0em 0.25em">
+<ul>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1928&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1928 (page does not exist)">1928</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1929&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1929 (page does not exist)">1929</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1930&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1930 (page does not exist)">1930</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1931&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1931 (page does not exist)">1931</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1932&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1932 (page does not exist)">1932</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1933&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1933 (page does not exist)">1933</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1934&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1934 (page does not exist)">1934</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1935&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1935 (page does not exist)">1935</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1936&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1936 (page does not exist)">1936</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1937&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1937 (page does not exist)">1937</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1938&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1938 (page does not exist)">1938</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1939&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1939 (page does not exist)">1939</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1940&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1940 (page does not exist)">1940</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1941&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1941 (page does not exist)">1941</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1942&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1942 (page does not exist)">1942</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1943&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1943 (page does not exist)">1943</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1944&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1944 (page does not exist)">1944</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1945&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1945 (page does not exist)">1945</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1946&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1946 (page does not exist)">1946</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1947&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1947 (page does not exist)">1947</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1948&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1948 (page does not exist)">1948</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1949&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1949 (page does not exist)">1949</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1940&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1940 (page does not exist)">1950</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1951&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1951 (page does not exist)">1951</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1952&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1952 (page does not exist)">1952</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1953&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1953 (page does not exist)">1953</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1954&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1954 (page does not exist)">1954</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1955&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1955 (page does not exist)">1955</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1956&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1956 (page does not exist)">1956</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1957&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1957 (page does not exist)">1957</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1958&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1958 (page does not exist)">1958</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1959&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1959 (page does not exist)">1959</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1960&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1960 (page does not exist)">1960</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1961&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1961 (page does not exist)">1961</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1962&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1962 (page does not exist)">1962</a></li>
+<li><a href="/w/index.php?title=United_States_gubernatorial_elections,_1963&amp;action=edit&amp;redlink=1" class="new" title="United States gubernatorial elections, 1963 (page does not exist)">1963</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1964" title="United States gubernatorial elections, 1964">1964</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1965" title="United States gubernatorial elections, 1965">1965</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1966" title="United States gubernatorial elections, 1966">1966</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1967" title="United States gubernatorial elections, 1967">1967</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1968" title="United States gubernatorial elections, 1968">1968</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1969" title="United States gubernatorial elections, 1969">1969</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1970" title="United States gubernatorial elections, 1970">1970</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1971" title="United States gubernatorial elections, 1971">1971</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1972" title="United States gubernatorial elections, 1972">1972</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1973" title="United States gubernatorial elections, 1973">1973</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1974" title="United States gubernatorial elections, 1974">1974</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1975" title="United States gubernatorial elections, 1975">1975</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1976" title="United States gubernatorial elections, 1976">1976</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1977" title="United States gubernatorial elections, 1977">1977</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1978" title="United States gubernatorial elections, 1978">1978</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1979" title="United States gubernatorial elections, 1979">1979</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1980" title="United States gubernatorial elections, 1980">1980</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1981" title="United States gubernatorial elections, 1981">1981</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1982" title="United States gubernatorial elections, 1982">1982</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1983" title="United States gubernatorial elections, 1983">1983</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1984" title="United States gubernatorial elections, 1984">1984</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1985" title="United States gubernatorial elections, 1985">1985</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1986" title="United States gubernatorial elections, 1986">1986</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1987" title="United States gubernatorial elections, 1987">1987</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1988" title="United States gubernatorial elections, 1988">1988</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1989" title="United States gubernatorial elections, 1989">1989</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1990" title="United States gubernatorial elections, 1990">1990</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1991" title="United States gubernatorial elections, 1991">1991</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1992" title="United States gubernatorial elections, 1992">1992</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1993" title="United States gubernatorial elections, 1993">1993</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1994" title="United States gubernatorial elections, 1994">1994</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1995" title="United States gubernatorial elections, 1995">1995</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1996" title="United States gubernatorial elections, 1996">1996</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1997" title="United States gubernatorial elections, 1997">1997</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1998" title="United States gubernatorial elections, 1998">1998</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_1999" title="United States gubernatorial elections, 1999">1999</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2000" title="United States gubernatorial elections, 2000">2000</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2001" title="United States gubernatorial elections, 2001">2001</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2002" title="United States gubernatorial elections, 2002">2002</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2003" title="United States gubernatorial elections, 2003">2003</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2004" title="United States gubernatorial elections, 2004">2004</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2005" title="United States gubernatorial elections, 2005">2005</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2006" title="United States gubernatorial elections, 2006">2006</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2007" title="United States gubernatorial elections, 2007">2007</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2008" title="United States gubernatorial elections, 2008">2008</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2009" title="United States gubernatorial elections, 2009">2009</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2010" title="United States gubernatorial elections, 2010">2010</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2011" title="United States gubernatorial elections, 2011">2011</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2012" title="United States gubernatorial elections, 2012">2012</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2013" title="United States gubernatorial elections, 2013">2013</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2014" title="United States gubernatorial elections, 2014">2014</a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2015" title="United States gubernatorial elections, 2015">2015</a></li>
+<li><strong class="selflink"><i>2016</i></strong></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2017" title="United States gubernatorial elections, 2017"><i>2017</i></a></li>
+<li><a href="/wiki/United_States_gubernatorial_elections,_2018" title="United States gubernatorial elections, 2018"><i>2018</i></a></li>
+</ul>
+</div>
+</td>
+</tr>
+<tr style="height:2px">
+<td colspan="2"></td>
+</tr>
+<tr>
+<td class="navbox-abovebelow" colspan="2">
+<div>
+<ul>
+<li><a href="/wiki/Template:United_States_House_of_Representatives_elections" title="Template:United States House of Representatives elections">House elections</a></li>
+<li><a href="/wiki/Template:United_States_Senate_elections" title="Template:United States Senate elections">Senate elections</a></li>
+<li><a href="/wiki/Template:United_States_presidential_elections" title="Template:United States presidential elections">Presidential elections</a></li>
+</ul>
+</div>
+</td>
+</tr>
+</table>
+</div>
+
+
+<!-- Saved in parser cache with key enwiki:pcache:idhash:38702920-0!*!0!!en!4!* and timestamp 20161005164123 and revision id 742759949
+ -->
+<noscript><img src="//en.wikipedia.org/wiki/Special:CentralAutoLogin/start?type=1x1" alt="" title="" width="1" height="1" style="border: none; position: absolute;" /></noscript></div>					<div class="printfooter">
+						Retrieved from "<a dir="ltr" href="https://en.wikipedia.org/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;oldid=742759949">https://en.wikipedia.org/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;oldid=742759949</a>"					</div>
+				<div id="catlinks" class="catlinks" data-mw="interface"><div id="mw-normal-catlinks" class="mw-normal-catlinks"><a href="/wiki/Help:Category" title="Help:Category">Categories</a>: <ul><li><a href="/wiki/Category:United_States_gubernatorial_elections,_2016" title="Category:United States gubernatorial elections, 2016">United States gubernatorial elections, 2016</a></li></ul></div><div id="mw-hidden-catlinks" class="mw-hidden-catlinks mw-hidden-cats-hidden">Hidden categories: <ul><li><a href="/wiki/Category:Use_mdy_dates_from_January_2016" title="Category:Use mdy dates from January 2016">Use mdy dates from January 2016</a></li></ul></div></div>				<div class="visualClear"></div>
+							</div>
+		</div>
+		<div id="mw-navigation">
+			<h2>Navigation menu</h2>
+
+			<div id="mw-head">
+									<div id="p-personal" role="navigation" class="" aria-labelledby="p-personal-label">
+						<h3 id="p-personal-label">Personal tools</h3>
+						<ul>
+							<li id="pt-anonuserpage">Not logged in</li><li id="pt-anontalk"><a href="/wiki/Special:MyTalk" title="Discussion about edits from this IP address [n]" accesskey="n">Talk</a></li><li id="pt-anoncontribs"><a href="/wiki/Special:MyContributions" title="A list of edits made from this IP address [y]" accesskey="y">Contributions</a></li><li id="pt-createaccount"><a href="/w/index.php?title=Special:CreateAccount&amp;returnto=United+States+gubernatorial+elections%2C+2016" title="You are encouraged to create an account and log in; however, it is not mandatory">Create account</a></li><li id="pt-login"><a href="/w/index.php?title=Special:UserLogin&amp;returnto=United+States+gubernatorial+elections%2C+2016" title="You're encouraged to log in; however, it's not mandatory. [o]" accesskey="o">Log in</a></li>						</ul>
+					</div>
+									<div id="left-navigation">
+										<div id="p-namespaces" role="navigation" class="vectorTabs" aria-labelledby="p-namespaces-label">
+						<h3 id="p-namespaces-label">Namespaces</h3>
+						<ul>
+															<li  id="ca-nstab-main" class="selected"><span><a href="/wiki/United_States_gubernatorial_elections,_2016"  title="View the content page [c]" accesskey="c">Article</a></span></li>
+															<li  id="ca-talk"><span><a href="/wiki/Talk:United_States_gubernatorial_elections,_2016"  title="Discussion about the content page [t]" accesskey="t" rel="discussion">Talk</a></span></li>
+													</ul>
+					</div>
+										<div id="p-variants" role="navigation" class="vectorMenu emptyPortlet" aria-labelledby="p-variants-label">
+												<h3 id="p-variants-label">
+							<span>Variants</span><a href="#"></a>
+						</h3>
+
+						<div class="menu">
+							<ul>
+															</ul>
+						</div>
+					</div>
+									</div>
+				<div id="right-navigation">
+										<div id="p-views" role="navigation" class="vectorTabs" aria-labelledby="p-views-label">
+						<h3 id="p-views-label">Views</h3>
+						<ul>
+															<li id="ca-view" class="selected"><span><a href="/wiki/United_States_gubernatorial_elections,_2016" >Read</a></span></li>
+															<li id="ca-edit"><span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=edit"  title="Edit this page [e]" accesskey="e">Edit</a></span></li>
+															<li id="ca-history" class="collapsible"><span><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=history"  title="Past revisions of this page [h]" accesskey="h">View history</a></span></li>
+													</ul>
+					</div>
+										<div id="p-cactions" role="navigation" class="vectorMenu emptyPortlet" aria-labelledby="p-cactions-label">
+						<h3 id="p-cactions-label"><span>More</span><a href="#"></a></h3>
+
+						<div class="menu">
+							<ul>
+															</ul>
+						</div>
+					</div>
+										<div id="p-search" role="search">
+						<h3>
+							<label for="searchInput">Search</label>
+						</h3>
+
+						<form action="/w/index.php" id="searchform">
+							<div id="simpleSearch">
+							<input type="search" name="search" placeholder="Search" title="Search Wikipedia [f]" accesskey="f" id="searchInput"/><input type="hidden" value="Special:Search" name="title"/><input type="submit" name="fulltext" value="Search" title="Search Wikipedia for this text" id="mw-searchButton" class="searchButton mw-fallbackSearchButton"/><input type="submit" name="go" value="Go" title="Go to a page with this exact name if it exists" id="searchButton" class="searchButton"/>							</div>
+						</form>
+					</div>
+									</div>
+			</div>
+			<div id="mw-panel">
+				<div id="p-logo" role="banner"><a class="mw-wiki-logo" href="/wiki/Main_Page"  title="Visit the main page"></a></div>
+						<div class="portal" role="navigation" id='p-navigation' aria-labelledby='p-navigation-label'>
+			<h3 id='p-navigation-label'>Navigation</h3>
+
+			<div class="body">
+									<ul>
+						<li id="n-mainpage-description"><a href="/wiki/Main_Page" title="Visit the main page [z]" accesskey="z">Main page</a></li><li id="n-contents"><a href="/wiki/Portal:Contents" title="Guides to browsing Wikipedia">Contents</a></li><li id="n-featuredcontent"><a href="/wiki/Portal:Featured_content" title="Featured content – the best of Wikipedia">Featured content</a></li><li id="n-currentevents"><a href="/wiki/Portal:Current_events" title="Find background information on current events">Current events</a></li><li id="n-randompage"><a href="/wiki/Special:Random" title="Load a random article [x]" accesskey="x">Random article</a></li><li id="n-sitesupport"><a href="https://donate.wikimedia.org/wiki/Special:FundraiserRedirector?utm_source=donate&amp;utm_medium=sidebar&amp;utm_campaign=C13_en.wikipedia.org&amp;uselang=en" title="Support us">Donate to Wikipedia</a></li><li id="n-shoplink"><a href="//shop.wikimedia.org" title="Visit the Wikipedia store">Wikipedia store</a></li>					</ul>
+							</div>
+		</div>
+			<div class="portal" role="navigation" id='p-interaction' aria-labelledby='p-interaction-label'>
+			<h3 id='p-interaction-label'>Interaction</h3>
+
+			<div class="body">
+									<ul>
+						<li id="n-help"><a href="/wiki/Help:Contents" title="Guidance on how to use and edit Wikipedia">Help</a></li><li id="n-aboutsite"><a href="/wiki/Wikipedia:About" title="Find out about Wikipedia">About Wikipedia</a></li><li id="n-portal"><a href="/wiki/Wikipedia:Community_portal" title="About the project, what you can do, where to find things">Community portal</a></li><li id="n-recentchanges"><a href="/wiki/Special:RecentChanges" title="A list of recent changes in the wiki [r]" accesskey="r">Recent changes</a></li><li id="n-contactpage"><a href="//en.wikipedia.org/wiki/Wikipedia:Contact_us" title="How to contact Wikipedia">Contact page</a></li>					</ul>
+							</div>
+		</div>
+			<div class="portal" role="navigation" id='p-tb' aria-labelledby='p-tb-label'>
+			<h3 id='p-tb-label'>Tools</h3>
+
+			<div class="body">
+									<ul>
+						<li id="t-whatlinkshere"><a href="/wiki/Special:WhatLinksHere/United_States_gubernatorial_elections,_2016" title="List of all English Wikipedia pages containing links to this page [j]" accesskey="j">What links here</a></li><li id="t-recentchangeslinked"><a href="/wiki/Special:RecentChangesLinked/United_States_gubernatorial_elections,_2016" title="Recent changes in pages linked from this page [k]" accesskey="k">Related changes</a></li><li id="t-upload"><a href="/wiki/Wikipedia:File_Upload_Wizard" title="Upload files [u]" accesskey="u">Upload file</a></li><li id="t-specialpages"><a href="/wiki/Special:SpecialPages" title="A list of all special pages [q]" accesskey="q">Special pages</a></li><li id="t-permalink"><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;oldid=742759949" title="Permanent link to this revision of the page">Permanent link</a></li><li id="t-info"><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;action=info" title="More information about this page">Page information</a></li><li id="t-wikibase"><a href="https://www.wikidata.org/wiki/Q6496595" title="Link to connected data repository item [g]" accesskey="g">Wikidata item</a></li><li id="t-cite"><a href="/w/index.php?title=Special:CiteThisPage&amp;page=United_States_gubernatorial_elections%2C_2016&amp;id=742759949" title="Information on how to cite this page">Cite this page</a></li>					</ul>
+							</div>
+		</div>
+			<div class="portal" role="navigation" id='p-coll-print_export' aria-labelledby='p-coll-print_export-label'>
+			<h3 id='p-coll-print_export-label'>Print/export</h3>
+
+			<div class="body">
+									<ul>
+						<li id="coll-create_a_book"><a href="/w/index.php?title=Special:Book&amp;bookcmd=book_creator&amp;referer=United+States+gubernatorial+elections%2C+2016">Create a book</a></li><li id="coll-download-as-rdf2latex"><a href="/w/index.php?title=Special:Book&amp;bookcmd=render_article&amp;arttitle=United+States+gubernatorial+elections%2C+2016&amp;returnto=United+States+gubernatorial+elections%2C+2016&amp;oldid=742759949&amp;writer=rdf2latex">Download as PDF</a></li><li id="t-print"><a href="/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;printable=yes" title="Printable version of this page [p]" accesskey="p">Printable version</a></li>					</ul>
+							</div>
+		</div>
+			<div class="portal" role="navigation" id='p-lang' aria-labelledby='p-lang-label'>
+			<h3 id='p-lang-label'>Languages</h3>
+
+			<div class="body">
+									<ul>
+						<li class="uls-p-lang-dummy"><a href="#"></a></li>					</ul>
+				<div class='after-portlet after-portlet-lang'><span class="wb-langlinks-add wb-langlinks-link"><a href="https://www.wikidata.org/wiki/Q6496595#sitelinks-wikipedia" title="Add interlanguage links" class="wbc-editpage">Add links</a></span></div>			</div>
+		</div>
+				</div>
+		</div>
+		<div id="footer" role="contentinfo">
+							<ul id="footer-info">
+											<li id="footer-info-lastmod"> This page was last modified on 5 October 2016, at 16:41.</li>
+											<li id="footer-info-copyright">Text is available under the <a rel="license" href="//en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License">Creative Commons Attribution-ShareAlike License</a><a rel="license" href="//creativecommons.org/licenses/by-sa/3.0/" style="display:none;"></a>;
+additional terms may apply.  By using this site, you agree to the <a href="//wikimediafoundation.org/wiki/Terms_of_Use">Terms of Use</a> and <a href="//wikimediafoundation.org/wiki/Privacy_policy">Privacy Policy</a>. Wikipedia® is a registered trademark of the <a href="//www.wikimediafoundation.org/">Wikimedia Foundation, Inc.</a>, a non-profit organization.</li>
+									</ul>
+							<ul id="footer-places">
+											<li id="footer-places-privacy"><a href="https://wikimediafoundation.org/wiki/Privacy_policy" class="extiw" title="wmf:Privacy policy">Privacy policy</a></li>
+											<li id="footer-places-about"><a href="/wiki/Wikipedia:About" title="Wikipedia:About">About Wikipedia</a></li>
+											<li id="footer-places-disclaimer"><a href="/wiki/Wikipedia:General_disclaimer" title="Wikipedia:General disclaimer">Disclaimers</a></li>
+											<li id="footer-places-contact"><a href="//en.wikipedia.org/wiki/Wikipedia:Contact_us">Contact Wikipedia</a></li>
+											<li id="footer-places-developers"><a href="https://www.mediawiki.org/wiki/Special:MyLanguage/How_to_contribute">Developers</a></li>
+											<li id="footer-places-cookiestatement"><a href="https://wikimediafoundation.org/wiki/Cookie_statement">Cookie statement</a></li>
+											<li id="footer-places-mobileview"><a href="//en.m.wikipedia.org/w/index.php?title=United_States_gubernatorial_elections,_2016&amp;mobileaction=toggle_view_mobile" class="noprint stopMobileRedirectToggle">Mobile view</a></li>
+									</ul>
+										<ul id="footer-icons" class="noprint">
+											<li id="footer-copyrightico">
+							<a href="https://wikimediafoundation.org/"><img src="/static/images/wikimedia-button.png" srcset="/static/images/wikimedia-button-1.5x.png 1.5x, /static/images/wikimedia-button-2x.png 2x" width="88" height="31" alt="Wikimedia Foundation"/></a>						</li>
+											<li id="footer-poweredbyico">
+							<a href="//www.mediawiki.org/"><img src="/static/images/poweredby_mediawiki_88x31.png" alt="Powered by MediaWiki" srcset="/static/images/poweredby_mediawiki_132x47.png 1.5x, /static/images/poweredby_mediawiki_176x62.png 2x" width="88" height="31"/></a>						</li>
+									</ul>
+						<div style="clear:both"></div>
+		</div>
+		<script>(window.RLQ=window.RLQ||[]).push(function(){mw.loader.load(["ext.cite.a11y","mediawiki.toc","mediawiki.action.view.postEdit","site","mediawiki.user","mediawiki.hidpi","mediawiki.page.ready","mediawiki.searchSuggest","ext.gadget.teahouse","ext.gadget.ReferenceTooltips","ext.gadget.watchlist-notice","ext.gadget.DRN-wizard","ext.gadget.charinsert","ext.gadget.refToolbar","ext.gadget.extra-toolbar-buttons","ext.gadget.switcher","ext.gadget.featured-articles-links","mmv.bootstrap.autostart","ext.visualEditor.targetLoader","ext.eventLogging.subscriber","ext.wikimediaEvents","ext.navigationTiming","ext.uls.eventlogger","ext.uls.init","ext.centralNotice.geoIP","ext.centralNotice.startUp"]);});</script>
+<script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set( {
+    "wgPageParseReport": {
+        "limitreport": {
+            "cputime": "1.126",
+            "walltime": "1.363",
+            "ppvisitednodes": {
+                "value": 7744,
+                "limit": 1000000
+            },
+            "ppgeneratednodes": {
+                "value": 0,
+                "limit": 1500000
+            },
+            "postexpandincludesize": {
+                "value": 250812,
+                "limit": 2097152
+            },
+            "templateargumentsize": {
+                "value": 6178,
+                "limit": 2097152
+            },
+            "expansiondepth": {
+                "value": 12,
+                "limit": 40
+            },
+            "expensivefunctioncount": {
+                "value": 3,
+                "limit": 500
+            },
+            "entityaccesscount": {
+                "value": 0,
+                "limit": 400
+            },
+            "timingprofile": [
+                "100.00% 1045.616      1 -total",
+                " 61.90%  647.237      1 Template:Reflist",
+                " 25.85%  270.328     56 Template:Cite_news",
+                " 20.56%  214.942     36 Template:Cite_web",
+                " 17.76%  185.701      1 Template:Infobox_election",
+                "  9.30%   97.197      3 Template:Infobox_election/row",
+                "  3.84%   40.182      1 Template:Use_mdy_dates",
+                "  2.65%   27.721     10 Template:If_empty",
+                "  2.35%   24.581     13 Template:Main",
+                "  1.95%   20.344      1 Template:Max"
+            ]
+        },
+        "scribunto": {
+            "limitreport-timeusage": {
+                "value": "0.487",
+                "limit": "10.000"
+            },
+            "limitreport-memusage": {
+                "value": 4303210,
+                "limit": 52428800
+            }
+        },
+        "cachereport": {
+            "origin": "mw1167",
+            "timestamp": "20161005164124",
+            "ttl": 2592000,
+            "transientcontent": false
+        }
+    }
+} );});</script><script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgBackendResponseTime":64,"wgHostname":"mw1178"});});</script>
+	</body>
+</html>

--- a/test_candidate.py
+++ b/test_candidate.py
@@ -102,7 +102,8 @@ class TestCandidate(unittest.TestCase):
       ["Iowa", "not real", "Iowa", ""],  # error
       ["", "", "", ""],                  # error
       ["Alberta", "", "", ""],           # error
-      ("XX", "Hawaii at-large", "Hawaii", "at-large"),
+      ["XX", "Hawaii at-large", "Hawaii", "at-large"],
+      ["", "Utah 1", "Utah", "1st"],
     ]
     for k in cases:
       got = candidate.normalize_location(k[0], k[1])


### PR DESCRIPTION
We can't make wikipedia pages, because candidates aren't automatically 'notable'. Output the data we have as CSV instead. The wiki functionality is still there, but disabled. This now is more generic about parsing any wikipedia table with 'State' and 'Candidates' columns. 

Also work around an amusing bug (not ours) where Utah isn't recognised as a state.
